### PR TITLE
use Service.Fan (not Fanv2) if no swing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changes
+## 4.3.3
+- [Bug] Fixes error in heombridge-platform-helper "ReferenceError: log is not defined"
+- [Improvement] Adds Humidity information to the Aircon accessory
+- [Improvement] Adds TemperatureSensor accessory to give temperature and humidity information from Broadlink sensors
+- [Improvement] Adds HumiditySensor accessory to give humidity information from Broadlink sensors
+- [Improvement] Adds AirPurifier and HumidifierDehumidifier accessory from the original fork
 
 ## 4.3.2
 - [Improvement] Updated documentation around TV changes

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ key | description | example | default
 w1DeviceID (optional) | Updates device current temperature from a Raspberry Pi Wire-1 thermometers (i.e. ds18b20). Value is the Device ID | 28-0321544e531ff | 
 heatOnly (optional) | Forces the Aircon accessory to only operate in Heat mode | true | false
 coolOnly (optional) | Forces the Aircon accessory to only operate in Cool mode | true | false
+noHumidity (optional) | Removes Humidity information from the device. It will be removed when using w1Device or temperatureFilePath | true | false
 
 #### "data" key-value object
 The device can be setup to manage modes in one of two ways. If your AC unit accepts a hexcade to change mode only (without temperature details) you can set the mode keys (heat/cool) and then the temperatureX values to change the teperature. If your AC unit sends hexcodes that contain the mode AND temperature you can use the modeX codes alone.
@@ -73,6 +74,20 @@ key | description
 --- | -----------
 data | Hex data stored as string.
 pseudo-mode (optional) | The mode we set when this hex is sent. i.e. "heat" or "cool". For graphical purposes only (hence use of the term "pseudo"). Not recommended for ModeX key-values.
+
+### TemperatureSensor Accessory
+Adds a temperature and humidity sensor using the Broadlink device's sensors.
+key | description | example | default
+--- | ----------- | ------- | -------
+noHumidity (optional) | Removes Humidity information from the device. It will be removed when using w1Device or temperatureFilePath | true | false
+tempertureAdjustment (optional) | An adjustment value to tune the value from the value the broadlink returns | -5 | 0 
+humidityAdjustment (optional) | An adjustment value to tune the value from the value the broadlink returns | -5 | 0 
+
+### HumiditySensor Accessory
+Adds a temperature and humidity sensor using the Broadlink device's sensors.
+key | description | example | default
+--- | ----------- | ------- | -------
+humidityAdjustment (optional) | An adjustment value to tune the value from the value the broadlink returns | -5 | 0 
 
 ### TV Accessory
 

--- a/accessories/air-purifier.js
+++ b/accessories/air-purifier.js
@@ -1,0 +1,142 @@
+const FanAccessory = require('./fan');
+
+class AirPurifierAccessory extends FanAccessory {
+
+  serviceType () { return Service.AirPurifier }
+
+  async setSwitchState (hexData, previousValue) {
+    super.setSwitchState(hexData, previousValue);
+    
+    this.updateCurrentState()
+  }
+
+  // User requested a the target state be set
+  async setTargetState (hexData, previousValue) {
+      const { log, name, state } = this;
+
+      // Ignore if no change to the targetPosition
+      if (state.targetState === previousValue) return;
+
+      // Set the CurrentAirPurifierState to match the switch state
+      log(`${name} setTargetState: currently ${previousValue === 0 ? 'manual' : 'auto'}, changing to ${state.targetState === 0 ? 'manual' : 'auto'}`);
+
+      await this.performSend(hexData);
+  }
+
+  updateCurrentState() {
+    const { log, name, state, serviceManager } = this;
+
+    if (state.switchState === true) {
+      log(`${name} updateCurrentState: changing to purifying`);
+      state.currentState = Characteristic.CurrentAirPurifierState.PURIFYING_AIR
+
+    } else {
+      log(`${name} updateCurrentState: changing to idle`);
+      state.currentState = Characteristic.CurrentAirPurifierState.INACTIVE
+    }
+    
+    serviceManager.refreshCharacteristicUI(Characteristic.CurrentAirPurifierState);
+  }
+
+  configureServiceManager(serviceManager) {
+    const { config, data } = this;
+    let {
+      showLockPhysicalControls,
+      showSwingMode,
+      showRotationDirection,
+      hideSwingMode,
+      hideRotationDirection
+    } = config;
+
+    const {
+      on,
+      off,
+      targetStateManual,
+      targetStateAuto,
+      lockControls,
+      unlockControls,
+      swingToggle
+    } = data || {};
+
+    // Defaults
+    if (showLockPhysicalControls !== false) showLockPhysicalControls = true
+    if (showSwingMode !== false && hideSwingMode !== true) showSwingMode = true
+    if (showRotationDirection !== false && hideRotationDirection !== true) showRotationDirection = true
+
+    serviceManager.addToggleCharacteristic({
+      name: 'switchState',
+      type: Characteristic.On,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: {
+        onData: on,
+        offData: off,
+        setValuePromise: this.setSwitchState.bind(this)
+      }
+    });
+
+    serviceManager.addToggleCharacteristic({
+      name: 'currentState',
+      type: Characteristic.CurrentAirPurifierState,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: { }
+    });
+
+    serviceManager.addToggleCharacteristic({
+      name: 'targetState',
+      type: Characteristic.TargetAirPurifierState,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: {
+        onData: targetStateManual,
+        offData: targetStateAuto,
+        setValuePromise: this.setTargetState.bind(this)
+      }
+    });
+
+    if (showLockPhysicalControls) {
+      serviceManager.addToggleCharacteristic({
+        name: 'lockPhysicalControls',
+        type: Characteristic.LockPhysicalControls,
+        getMethod: this.getCharacteristicValue,
+        setMethod: this.setCharacteristicValue,
+        bind: this,
+        props: {
+          onData: lockControls,
+          offData: unlockControls
+        }
+      });
+    }
+
+    if (showSwingMode) {
+      serviceManager.addToggleCharacteristic({
+        name: 'swingMode',
+        type: Characteristic.SwingMode,
+        getMethod: this.getCharacteristicValue,
+        setMethod: this.setCharacteristicValue,
+        bind: this,
+        props: {
+          onData: swingToggle,
+          offData: swingToggle,
+        }
+      });
+    }
+
+    serviceManager.addToggleCharacteristic({
+      name: 'fanSpeed',
+      type: Characteristic.RotationSpeed,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: {
+        setValuePromise: this.setFanSpeed.bind(this)
+      }
+    });
+  }
+}
+
+module.exports = AirPurifierAccessory;

--- a/accessories/aircon.js
+++ b/accessories/aircon.js
@@ -57,6 +57,7 @@ class AirConAccessory extends BroadlinkRMAccessory {
     config.temperatureUpdateFrequency = config.temperatureUpdateFrequency || 10;
     config.units = config.units ? config.units.toLowerCase() : 'c';
     config.temperatureAdjustment = config.temperatureAdjustment || 0;
+    config.humidityAdjustment = config.humidityAdjustment || 0;
     config.autoSwitchName = config.autoSwitch || config.autoSwitchName;
 
     if (config.preventResendHex === undefined && config.allowResend === undefined) {
@@ -69,6 +70,13 @@ class AirConAccessory extends BroadlinkRMAccessory {
     // default temperatures
     config.defaultCoolTemperature = config.defaultCoolTemperature || 16;
     config.defaultHeatTemperature = config.defaultHeatTemperature || 30;
+    // ignore Humidity if set to not use it, or using Temperature source that doesn't support it
+    if(config.noHumidity || config.w1Device || config.temperatureFilePath){
+      state.currentHumidity = null;
+      config.noHumidity = true;
+    } else {
+      config.noHumidity = false;
+    }
 
     // Used to determine when we should use the defaultHeatTemperature or the
     // defaultHeatTemperature
@@ -189,14 +197,14 @@ class AirConAccessory extends BroadlinkRMAccessory {
 
       return;
     }
-    
+
     if (previousValue === Characteristic.TargetHeatingCoolingState.OFF) this.previouslyOff = true;
-      
+
     // If the air-conditioner is turned off then turn it on first and try this again
     if (this.checkTurnOnWhenOff()) {
       this.turnOnWhenOffDelayPromise = delayForDuration(.3);
       await this.turnOnWhenOffDelayPromise
-    } 
+    }
 
     // Perform the auto -> cool/heat conversion if `replaceAutoMode` is specified
     if (replaceAutoMode && targetHeatingCoolingState === 'auto') {
@@ -208,7 +216,7 @@ class AirConAccessory extends BroadlinkRMAccessory {
 
     let temperature = state.targetTemperature;
     let mode = HeatingCoolingConfigKeys[state.targetHeatingCoolingState];
-    
+
     if (state.currentHeatingCoolingState !== state.targetHeatingCoolingState){
       // Selecting a heating/cooling state allows a default temperature to be used for the given state.
       if (state.targetHeatingCoolingState === Characteristic.TargetHeatingCoolingState.HEAT) {
@@ -216,20 +224,20 @@ class AirConAccessory extends BroadlinkRMAccessory {
       } else if (state.targetHeatingCoolingState === Characteristic.TargetHeatingCoolingState.COOL) {
         temperature = defaultCoolTemperature;
       }
-      
+
       //Set the mode, and send the mode hex
       this.updateServiceCurrentHeatingCoolingState(state.targetHeatingCoolingState);
       if (data.heat && mode === 'heat'){
-        await this.performSend(data.heat);        
+        await this.performSend(data.heat);
       } else if (data.cool && mode === 'cool'){
-        await this.performSend(data.cool);        
+        await this.performSend(data.cool);
       } else if (data.auto && mode === 'auto'){
         await this.performSend(data.auto);
       } else if (hexData) {
         //Just send the provided temperature hex if no mode codes are set
         await this.performSend(hexData);
       }
-      
+
       this.log(`${name} sentMode (${mode})`);
 
       //Force Temperature send
@@ -238,7 +246,7 @@ class AirConAccessory extends BroadlinkRMAccessory {
         serviceManager.refreshCharacteristicUI(Characteristic.TargetTemperature);
       });
     }
-    
+
     serviceManager.refreshCharacteristicUI(Characteristic.CurrentHeatingCoolingState);
     serviceManager.refreshCharacteristicUI(Characteristic.TargetHeatingCoolingState);
   }
@@ -359,19 +367,29 @@ class AirConAccessory extends BroadlinkRMAccessory {
     if (!config.isUnitTest) setInterval(this.updateTemperatureUI.bind(this), config.temperatureUpdateFrequency * 1000)
   }
 
-  onTemperature (temperature) {
+  onTemperature (temperature,humidity) {
     const { config, host, log, name, state } = this;
-    const { minTemperature, maxTemperature, temperatureAdjustment } = config;
+    const { minTemperature, maxTemperature, temperatureAdjustment, humidityAdjustment, noHumidity } = config;
 
     // onTemperature is getting called twice. No known cause currently.
     // This helps prevent the same temperature from being processed twice
     if (Object.keys(this.temperatureCallbackQueue).length === 0) return;
 
-    temperature += temperatureAdjustment
-
+    temperature += temperatureAdjustment;
     state.currentTemperature = temperature;
-
     log(`${name} onTemperature (${temperature})`);
+
+    if(humidity) {
+      if(noHumidity){
+        //noHumidity = false;
+        //if(state.firstTemperatureUpdate){log (`${name} Humidity found, you can add support`);};
+        state.currentHumidity = null;
+      }else{
+        humidity += humidityAdjustment;
+        state.currentHumidity = humidity;
+        log(`${name} onHumidity (` + humidity + `)`);
+      }
+    }
 
     if (temperature > config.maxTemperature) {
       log(`\x1b[36m[INFO]\x1b[0m Reported temperature (${temperature}) is too high, setting to \x1b[33mmaxTemperature\x1b[0m (${maxTemperature}).`)
@@ -515,9 +533,11 @@ class AirConAccessory extends BroadlinkRMAccessory {
   }
 
   updateTemperatureUI () {
-    const { serviceManager } = this;
+    const { config, serviceManager } = this;
+    const { noHumidity } = config;
 
-    serviceManager.refreshCharacteristicUI(Characteristic.CurrentTemperature)
+    serviceManager.refreshCharacteristicUI(Characteristic.CurrentTemperature);
+    if(!noHumidity){serviceManager.refreshCharacteristicUI(Characteristic.CurrentRelativeHumidity);};
   }
 
   getCurrentTemperature (callback) {
@@ -532,6 +552,13 @@ class AirConAccessory extends BroadlinkRMAccessory {
     }
 
     this.addTemperatureCallbackToQueue(callback);
+  }
+
+  getCurrentHumidity (callback) {
+    const { config, host, debug, log, name, state } = this;
+    const { pseudoDeviceTemperature } = config;
+
+    return callback(null, state.currentHumidity);
   }
 
   async checkTemperatureForAutoOnOff (temperature) {
@@ -685,32 +712,41 @@ class AirConAccessory extends BroadlinkRMAccessory {
         ignorePreviousValue: true
       }
     });
-    
+
     if (config.heatOnly) {
       this.serviceManager
         .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-	  .setProps({
-	    minValue: 0,
-	    maxValue: 1,
-	    validValues: [0,1]
-	  });
-	}
+          .setProps({
+            minValue: 0,
+            maxValue: 1,
+            validValues: [0,1]
+          });
+        }
     if (config.coolOnly) {
       this.serviceManager
         .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-	  .setProps({
-	    minValue: 0,
-	    maxValue: 2,
-	    validValues: [0,2]
-	  });
-	}
+          .setProps({
+            minValue: 0,
+            maxValue: 2,
+            validValues: [0,2]
+          });
+        }
 
     this.serviceManager.addGetCharacteristic({
       name: 'currentTemperature',
       type: Characteristic.CurrentTemperature,
       method: this.getCurrentTemperature,
       bind: this
-    })
+    });
+
+    if (!config.noHumidity){
+      this.serviceManager.addGetCharacteristic({
+        name: 'currentHumidity',
+        type: Characteristic.CurrentRelativeHumidity,
+        method: this.getCurrentHumidity,
+        bind: this
+      })
+    };
 
     this.serviceManager.addGetCharacteristic({
       name: 'temperatureDisplayUnits',
@@ -718,7 +754,7 @@ class AirConAccessory extends BroadlinkRMAccessory {
       method: this.getTemperatureDisplayUnits,
       bind: this
     })
-    
+
     this.serviceManager
       .getCharacteristic(Characteristic.TargetTemperature)
       .setProps({

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -61,7 +61,7 @@ class FanAccessory extends SwitchAccessory {
     if (showSwingMode !== false && hideSwingMode !== true) showSwingMode = true
     if (showRotationDirection !== false && hideRotationDirection !== true) showRotationDirection = true
 
-    this.serviceManager = new ServiceManagerTypes[serviceManagerType](name, Service.Fanv2, this.log);
+    this.serviceManager = new ServiceManagerTypes[serviceManagerType](name, showSwingMode ? Service.Fanv2 : Service.Fan, this.log);
 
     this.serviceManager.addToggleCharacteristic({
       name: 'switchState',

--- a/accessories/humidifier-dehumidifier.js
+++ b/accessories/humidifier-dehumidifier.js
@@ -1,0 +1,176 @@
+const FanAccessory = require('./fan');
+
+class HumidifierDehumidifierAccessory extends FanAccessory {
+  
+  serviceType () { return Service.HumidifierDehumidifier }
+
+  setDefaults () {
+    super.setDefaults();
+
+    this.updateRelativeHumidity()
+  }
+
+  // User requested a the target state be set
+  async setTargetState (hexData, previousValue) {
+      const { log, name, state, serviceManager } = this;
+
+      // Ignore if no change to the targetPosition
+      if (state.targetState === previousValue) return;
+
+      // Set the CurrentHumidifierDehumidifierState to match the switch state
+      let currentState = Characteristic.CurrentHumidifierDehumidifierState.INACTIVE;
+
+      if (state.targetState === Characteristic.TargetHumidifierDehumidifierState.HUMIDIFIER_OR_DEHUMIDIFIER) {
+        currentState = Characteristic.CurrentHumidifierDehumidifierState.DEHUMIDIFYING
+      } else if (state.targetState === Characteristic.TargetHumidifierDehumidifierState.HUMIDIFIER) {
+        currentState = Characteristic.CurrentHumidifierDehumidifierState.HUMIDIFYING
+      } else if (state.targetState === Characteristic.TargetHumidifierDehumidifierState.DEHUMIDIFIER) {
+        currentState = Characteristic.CurrentHumidifierDehumidifierState.DEHUMIDIFYING
+      }
+
+      log(`${name} setTargetState: currently ${previousValue}, changing to ${state.targetState}`);
+
+      state.currentState = currentState
+      serviceManager.refreshCharacteristicUI(Characteristic.CurrentHumidifierDehumidifierState);
+
+      this.updateRelativeHumidity()
+
+      await this.performSend(hexData);
+  }
+
+  updateRelativeHumidity() {
+    let { serviceManager, state } = this;
+
+    state.currentRelativeHumidity = 35
+    state.targetRelativeHumidity = 5
+
+    if (state.targetState === Characteristic.TargetHumidifierDehumidifierState.HUMIDIFIER) {
+      state.currentRelativeHumidity = 5
+      state.targetRelativeHumidity = 15
+    } 
+
+    serviceManager.refreshCharacteristicUI(Characteristic.CurrentRelativeHumidity);
+    serviceManager.refreshCharacteristicUI(Characteristic.TargetRelativeHumidity);
+  }
+
+  configureServiceManager (serviceManager) {
+    const { config, data } = this;
+    let {
+      showLockPhysicalControls,
+      showSwingMode,
+      showRotationDirection,
+      hideSwingMode,
+      hideRotationDirection
+    } = config;
+
+    const {
+      on,
+      off,
+      targetStateHumidifier,
+      targetStateDehumidifier,
+      lockControls,
+      unlockControls,
+      swingToggle
+    } = data || {};
+
+    // Defaults
+    if (showLockPhysicalControls !== false) showLockPhysicalControls = true
+    if (showSwingMode !== false && hideSwingMode !== true) showSwingMode = true
+    if (showRotationDirection !== false && hideRotationDirection !== true) showRotationDirection = true
+
+    serviceManager.addToggleCharacteristic({
+      name: 'switchState',
+      type: Characteristic.On,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: {
+        onData: on,
+        offData: off,
+        setValuePromise: this.setSwitchState.bind(this)
+      }
+    });
+
+    serviceManager.addToggleCharacteristic({
+      name: 'currentRelativeHumidity',
+      type: Characteristic.CurrentRelativeHumidity,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: { }
+    });
+
+    serviceManager.addToggleCharacteristic({
+      name: 'targetRelativeHumidity',
+      type: Characteristic.TargetRelativeHumidity,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: { }
+    });
+
+    
+    serviceManager.addToggleCharacteristic({
+      name: 'currentState',
+      type: Characteristic.CurrentHumidifierDehumidifierState,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: { }
+    });
+    
+    serviceManager.addToggleCharacteristic({
+      name: 'targetState',
+      type: Characteristic.TargetHumidifierDehumidifierState,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: {
+        onData: targetStateHumidifier,
+        offData: targetStateDehumidifier,
+        setValuePromise: this.setTargetState.bind(this)
+      }
+    });
+
+    if (showLockPhysicalControls) {
+      serviceManager.addToggleCharacteristic({
+        name: 'lockPhysicalControls',
+        type: Characteristic.LockPhysicalControls,
+        getMethod: this.getCharacteristicValue,
+        setMethod: this.setCharacteristicValue,
+        bind: this,
+        props: {
+          onData: lockControls,
+          offData: unlockControls
+        }
+      });
+    }
+
+    if (showSwingMode) {
+      serviceManager.addToggleCharacteristic({
+        name: 'swingMode',
+        type: Characteristic.SwingMode,
+        getMethod: this.getCharacteristicValue,
+        setMethod: this.setCharacteristicValue,
+        bind: this,
+        props: {
+          onData: swingToggle,
+          offData: swingToggle,
+        }
+      });
+    }
+
+    serviceManager.addToggleCharacteristic({
+      name: 'fanSpeed',
+      type: Characteristic.RotationSpeed,
+      getMethod: this.getCharacteristicValue,
+      setMethod: this.setCharacteristicValue,
+      bind: this,
+      props: {
+        setValuePromise: this.setFanSpeed.bind(this)
+      }
+    });
+  }
+}
+
+module.exports = HumidifierDehumidifierAccessory;

--- a/accessories/humiditySensor.js
+++ b/accessories/humiditySensor.js
@@ -1,0 +1,151 @@
+const { assert } = require('chai');
+const uuid = require('uuid');
+const fs = require('fs');
+const findKey = require('find-key');
+
+const delayForDuration = require('../helpers/delayForDuration');
+const ServiceManagerTypes = require('../helpers/serviceManagerTypes');
+const catchDelayCancelError = require('../helpers/catchDelayCancelError');
+const { getDevice } = require('../helpers/getDevice');
+const BroadlinkRMAccessory = require('./accessory');
+
+class HumiditySensorAccessory extends BroadlinkRMAccessory {
+
+  constructor (log, config = {}, serviceManagerType) {
+    super(log, config, serviceManagerType);
+
+    this.humidityCallbackQueue = {};
+    this.monitorHumidity();
+  }
+
+  setDefaults () {
+    const { config, state } = this;
+
+    // Set config default values
+    config.humidityUpdateFrequency = config.humidityUpdateFrequency || 10;
+    config.humidityAdjustment = config.humidityAdjustment || 0;
+
+    state.firstHumidityUpdate = true;
+  }
+
+  reset () {
+    super.reset();
+  }
+
+  // Device Temperature Methods
+  async monitorHumidity () {
+    const { config, host, log, name, state } = this;
+
+    const device = getDevice({ host, log });
+
+    // Try again in a second if we don't have a device yet
+    if (!device) {
+      await delayForDuration(1);
+
+      this.monitorHumidity();
+
+      return;
+    }
+
+    log(`${name} monitorHumidity`);
+
+    //Broadlink module emits 'temperature for both sensors.
+    device.on('temperature', this.onHumidity.bind(this));
+    device.checkHumidity();
+
+    this.updateHumidityUI();
+    if (!config.isUnitTest) setInterval(this.updateHumidityUI.bind(this), config.humidityUpdateFrequency * 1000)
+  }
+
+  onHumidity (temperature,humidity) {
+    const { config, host, log, name, state } = this;
+    const { humidityAdjustment } = config;
+
+    // onHumidity is getting called twice. No known cause currently.
+    // This helps prevent the same humidity from being processed twice
+    if (Object.keys(this.humidityCallbackQueue).length === 0) return;
+
+    humidity += humidityAdjustment;
+    state.currentHumidity = humidity;
+    log(`${name} onHumidity (` + humidity + `)`);
+
+    this.processQueuedHumidityCallbacks(humidity);
+  }
+
+  addHumidityCallbackToQueue (callback) {
+    const { config, host, debug, log, name, state } = this;
+    
+    // Clear the previous callback
+    if (Object.keys(this.humidityCallbackQueue).length > 1) {
+      if (state.currentHumidity) {
+        if (debug) log(`\x1b[34m[DEBUG]\x1b[0m ${name} addHumidityCallbackToQueue (clearing previous callback, using existing humidity)`);
+
+        this.processQueuedHumidityCallbacks(state.currentHumidity);
+      }
+    }
+
+    // Add a new callback
+    const callbackIdentifier = uuid.v4();
+    this.humidityCallbackQueue[callbackIdentifier] = callback;
+
+    // Read temperature from Broadlink RM device
+    // If the device is no longer available, use previous tempeature
+    const device = getDevice({ host, log });
+
+    if (!device || device.state === 'inactive') {
+      if (device && device.state === 'inactive') {
+        log(`${name} addHumidityCallbackToQueue (device no longer active, using existing humidity)`);
+      }
+
+      this.processQueuedHumidityCallbacks(state.currentHumidity || 0);
+
+      return;
+    }
+
+    device.checkHumidity();
+    if (debug) log(`\x1b[34m[DEBUG]\x1b[0m ${name} addHumidityCallbackToQueue (requested humidity from device, waiting)`);
+  }
+
+  processQueuedHumidityCallbacks (humidity) {
+    if (Object.keys(this.humidityCallbackQueue).length === 0) return;
+
+    Object.keys(this.humidityCallbackQueue).forEach((callbackIdentifier) => {
+      const callback = this.humidityCallbackQueue[callbackIdentifier];
+
+      callback(null, humidity);
+      delete this.humidityCallbackQueue[callbackIdentifier];
+    })
+
+    this.humidityCallbackQueue = {};
+  }
+
+  updateHumidityUI () {
+    const { config, serviceManager } = this;
+
+    serviceManager.refreshCharacteristicUI(Characteristic.CurrentRelativeHumidity);
+  }
+
+  getCurrentHumidity (callback) {
+    const { config, host, debug, log, name, state } = this;
+    const { pseudoDeviceTemperature } = config;
+
+    this.addHumidityCallbackToQueue(callback);
+  }
+  
+  // Service Manager Setup
+
+  setupServiceManager () {
+    const { config, name, serviceManagerType } = this;
+
+    this.serviceManager = new ServiceManagerTypes[serviceManagerType](name, Service.HumiditySensor, this.log);
+
+    this.serviceManager.addGetCharacteristic({
+      name: 'currentHumidity',
+      type: Characteristic.CurrentRelativeHumidity,
+      method: this.getCurrentHumidity,
+      bind: this
+    });
+  }
+}
+
+module.exports = HumiditySensorAccessory

--- a/accessories/index.js
+++ b/accessories/index.js
@@ -1,4 +1,6 @@
 const AirCon = require('./aircon');
+const AirPurifier = require('./air-purifier');
+const HumidifierDehumidifier = require('./humidifier-dehumidifier');
 const LearnCode = require('./learnCode');
 const Outlet = require('./outlet');
 const Switch = require('./switch');
@@ -9,11 +11,16 @@ const Fan = require('./fan');
 const GarageDoorOpener = require('./garageDoorOpener');
 const Lock = require('./lock');
 const Light = require('./light');
+const Window = require('./window');
 const WindowCovering = require('./windowCovering');
 const TV = require('./tv');
+const TemperatureSensor = require('./temperatureSensor.js');
+const HumiditySensor = require('./humiditySensor.js');
 
 module.exports = {
   AirCon,
+  AirPurifier,
+  HumidifierDehumidifier,
   LearnCode,
   Switch,
   SwitchMulti,
@@ -24,6 +31,9 @@ module.exports = {
   GarageDoorOpener,
   Lock,
   Light,
+  Window,
   WindowCovering,
-  TV
+  TV,
+  TemperatureSensor,
+  HumiditySensor
 }

--- a/accessories/temperatureSensor.js
+++ b/accessories/temperatureSensor.js
@@ -1,0 +1,225 @@
+const { assert } = require('chai');
+const uuid = require('uuid');
+const fs = require('fs');
+const findKey = require('find-key');
+
+const delayForDuration = require('../helpers/delayForDuration');
+const ServiceManagerTypes = require('../helpers/serviceManagerTypes');
+const catchDelayCancelError = require('../helpers/catchDelayCancelError');
+const { getDevice } = require('../helpers/getDevice');
+const BroadlinkRMAccessory = require('./accessory');
+
+class TemperatureSensorAccessory extends BroadlinkRMAccessory {
+
+  constructor (log, config = {}, serviceManagerType) {
+    super(log, config, serviceManagerType);
+
+    this.temperatureCallbackQueue = {};
+    this.monitorTemperature();
+  }
+
+  setDefaults () {
+    const { config, state } = this;
+
+    // Set config default values
+    config.temperatureUpdateFrequency = config.temperatureUpdateFrequency || 10;
+    config.units = config.units ? config.units.toLowerCase() : 'c';
+    config.temperatureAdjustment = config.temperatureAdjustment || 0;
+    config.humidityAdjustment = config.humidityAdjustment || 0;
+
+    // ignore Humidity if set to not use it, or using Temperature source that doesn't support it
+    if(config.noHumidity){
+      state.currentHumidity = null;
+      config.noHumidity = true;
+    } else {
+      config.noHumidity = false;
+    }
+
+    state.firstTemperatureUpdate = true;
+  }
+
+  reset () {
+    super.reset();
+  }
+
+  // Device Temperature Methods
+  async monitorTemperature () {
+    const { config, host, log, name, state } = this;
+    const { temperatureFilePath, pseudoDeviceTemperature, w1DeviceID } = config;
+
+    if (pseudoDeviceTemperature !== undefined) return;
+
+    //Force w1 and file devices to a 10 minute refresh
+    if (w1DeviceID || temperatureFilePath) config.temperatureUpdateFrequency = 600;
+
+    const device = getDevice({ host, log });
+
+    // Try again in a second if we don't have a device yet
+    if (!device) {
+      await delayForDuration(1);
+
+      this.monitorTemperature();
+
+      return;
+    }
+
+    log(`${name} monitorTemperature`);
+
+    device.on('temperature', this.onTemperature.bind(this));
+    device.checkTemperature();
+
+    this.updateTemperatureUI();
+    if (!config.isUnitTest) setInterval(this.updateTemperatureUI.bind(this), config.temperatureUpdateFrequency * 1000)
+  }
+
+  onTemperature (temperature,humidity) {
+    const { config, host, log, name, state } = this;
+    const { minTemperature, maxTemperature, temperatureAdjustment, humidityAdjustment, noHumidity } = config;
+
+    // onTemperature is getting called twice. No known cause currently.
+    // This helps prevent the same temperature from being processed twice
+    if (Object.keys(this.temperatureCallbackQueue).length === 0) return;
+
+    temperature += temperatureAdjustment;
+    state.currentTemperature = temperature;
+    log(`${name} onTemperature (${temperature})`);
+
+    if(humidity) {
+      if(noHumidity){
+        //noHumidity = false;
+        log (`${name} Humidity found, adding support`);
+        state.currentHumidity = null;
+      }else{
+        humidity += humidityAdjustment;
+        state.currentHumidity = humidity;
+        log(`${name} onHumidity (` + humidity + `)`);
+      }
+    }
+
+    this.processQueuedTemperatureCallbacks(temperature);
+  }
+
+  addTemperatureCallbackToQueue (callback) {
+    const { config, host, debug, log, name, state } = this;
+    
+    // Clear the previous callback
+    if (Object.keys(this.temperatureCallbackQueue).length > 1) {
+      if (state.currentTemperature) {
+        if (debug) log(`\x1b[34m[DEBUG]\x1b[0m ${name} addTemperatureCallbackToQueue (clearing previous callback, using existing temperature)`);
+
+        this.processQueuedTemperatureCallbacks(state.currentTemperature);
+      }
+    }
+
+    // Add a new callback
+    const callbackIdentifier = uuid.v4();
+    this.temperatureCallbackQueue[callbackIdentifier] = callback;
+
+    // Read temperature from Broadlink RM device
+    // If the device is no longer available, use previous tempeature
+    const device = getDevice({ host, log });
+
+    if (!device || device.state === 'inactive') {
+      if (device && device.state === 'inactive') {
+        log(`${name} addTemperatureCallbackToQueue (device no longer active, using existing temperature)`);
+      }
+
+      this.processQueuedTemperatureCallbacks(state.currentTemperature || 0);
+
+      return;
+    }
+
+    device.checkTemperature();
+    if (debug) log(`\x1b[34m[DEBUG]\x1b[0m ${name} addTemperatureCallbackToQueue (requested temperature from device, waiting)`);
+  }
+
+  processQueuedTemperatureCallbacks (temperature) {
+    if (Object.keys(this.temperatureCallbackQueue).length === 0) return;
+
+    Object.keys(this.temperatureCallbackQueue).forEach((callbackIdentifier) => {
+      const callback = this.temperatureCallbackQueue[callbackIdentifier];
+
+      callback(null, temperature);
+      delete this.temperatureCallbackQueue[callbackIdentifier];
+    })
+
+    this.temperatureCallbackQueue = {};
+  }
+
+  updateTemperatureUI () {
+    const { config, serviceManager } = this;
+    const { noHumidity } = config;
+
+    serviceManager.refreshCharacteristicUI(Characteristic.CurrentTemperature);
+    if(!noHumidity){serviceManager.refreshCharacteristicUI(Characteristic.CurrentRelativeHumidity);};
+  }
+
+  getCurrentTemperature (callback) {
+    const { config, host, debug, log, name, state } = this;
+    const { pseudoDeviceTemperature } = config;
+
+    // Some devices don't include a thermometer and so we can use `pseudoDeviceTemperature` instead
+    if (pseudoDeviceTemperature !== undefined) {
+      if (debug) log(`\x1b[34m[DEBUG]\x1b[0m ${name} getCurrentTemperature (using pseudoDeviceTemperature ${pseudoDeviceTemperature} from config)`);
+
+      return callback(null, pseudoDeviceTemperature);
+    }
+
+    this.addTemperatureCallbackToQueue(callback);
+  }
+
+  getCurrentHumidity (callback) {
+    const { config, host, debug, log, name, state } = this;
+    const { pseudoDeviceTemperature } = config;
+
+    return callback(null, state.currentHumidity);
+  }
+
+  getTemperatureDisplayUnits (callback) {
+    const { config } = this;
+
+    const temperatureDisplayUnits = (config.units.toLowerCase() === 'f') ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS;
+
+    callback(temperatureDisplayUnits);
+  }
+
+  
+  // Service Manager Setup
+
+  setupServiceManager () {
+    const { config, name, serviceManagerType } = this;
+
+    this.serviceManager = new ServiceManagerTypes[serviceManagerType](name, Service.TemperatureSensor, this.log);
+
+    this.serviceManager.addGetCharacteristic({
+      name: 'currentTemperature',
+      type: Characteristic.CurrentTemperature,
+      method: this.getCurrentTemperature,
+      bind: this
+    });
+
+    if (!config.noHumidity){
+      this.serviceManager.addGetCharacteristic({
+        name: 'currentHumidity',
+        type: Characteristic.CurrentRelativeHumidity,
+        method: this.getCurrentHumidity,
+        bind: this
+      })
+    };
+
+    this.serviceManager.addGetCharacteristic({
+      name: 'temperatureDisplayUnits',
+      type: Characteristic.TemperatureDisplayUnits,
+      method: this.getTemperatureDisplayUnits,
+      bind: this
+    })
+
+    this.serviceManager
+      .getCharacteristic(Characteristic.CurrentTemperature)
+      .setProps({
+        minStep: 0.1
+      });
+  }
+}
+
+module.exports = TemperatureSensorAccessory

--- a/accessories/window.js
+++ b/accessories/window.js
@@ -1,0 +1,6 @@
+const WindowCoveringAccessory = require('./windowCovering');
+
+class WindowAccessory extends WindowCoveringAccessory {
+  serviceType () { return Service.Window }
+}
+module.exports = WindowAccessory;

--- a/config-sample.json
+++ b/config-sample.json
@@ -78,18 +78,18 @@
 					"hue359": "2600500000012..."
 				}
 			},
-      {
-        "name": "LivingRoom Humidity",
-        "type": "humiditySensor"
-      },
-      {
-        "name": "LivingRoom temperature",
-        "type": "temperatureSensor"
-      },
+			{
+				"name": "LivingRoom Humidity",
+				"type": "humiditySensor"
+			},
+			{
+				"name": "LivingRoom temperature",
+				"type": "temperatureSensor"
+			},
 			{
 				"name": "Air Conditioner",
 				"type": "air-conditioner",
-        "noHumidity": true,
+				"noHumidity": true,
 				"data": {
 					"off": "2600500000012...",
 					"temperature30": {

--- a/config-sample.json
+++ b/config-sample.json
@@ -1,307 +1,266 @@
 {
-  "bridge":{
-    "name":"Homebridge",
-    "username":"CD:22:3D:E3:CE:30",
-    "port":51826,
-    "pin":"031-45-154"
-  },
-  "description":"Homebridge",
-  "accessories":[
+	"bridge": {
+		"name": "Homebridge",
+		"username": "CD:22:3D:E3:CE:30",
+		"port": 51826,
+		"pin": "031-45-154"
+	},
+	"description": "Homebridge",
+	"accessories": [
 
-  ],
-  "platforms":[
-    {
-      "platform":"BroadlinkRM",
-      "name":"Broadlink RM",
-      "hideScanFrequencyButton": false,
-      "hideLearnButton": false,
-      "hideWelcomeMessage": false,
-      "accessories":[
-        {
-          "name":"Auto-off Switch",
-          "type":"switch",
-          "enableAutoOff": true,
-          "onDuration": 5,
-          "data":{
-            "on":"2600500000012...",
-            "off":"2600500000012..."
-          }
-        },
-        {
-          "name":"TV On/Off",
-          "type":"switch",
-          "data":{
-            "on":"2600500000012...",
-            "off":"2600500000012..."
-          }
-        },
-        {
-          "name":"Channel Up",
-          "type":"switch",
-          "data":"CHANNEL_UP_HEX...",
-          "enableAutoOff": true,
-          "onDuration": 1
-        },
-        {
-          "name":"Channel Down",
-          "type":"switch",
-          "enableAutoOff": true,
-          "onDuration": 1,
-          "data":"CHANNEL_DOWN_HEX..."
-        },
-        {
-          "name":"Volume Up",
-          "type":"switch",
-          "enableAutoOff": true,
-          "onDuration": 2.5,
-          "data": [
-            {
-              "data": "VOLUME_UP_HEX...",
-              "sendCount": 5,
-              "interval": 0.3
-            }
-          ]
-        },
-        {
-          "name":"Volume Down",
-          "type":"switch",
-          "enableAutoOff": true,
-          "onDuration": 2.5,
-          "data": [
-            {
-              "data": "VOLUME_DOWN_HEX...",
-              "sendCount": 5,
-              "interval": 0.3
-            }
-          ]
-        },
-        {
-          "name":"Entertainment",
-          "type":"switch",
-          "enableAutoOff": true,
-          "onDuration": 1.5,
-          "data":[
-            {
-              "data": "HEX_1...",
-              "pause": 0.3
-            },
-            {
-              "data": "HEX_2...",
-              "pause": 0.3
-            },
-            {
-              "data": "HEX_3...",
-              "pause": 0.3
-            }
-          ]
-        },
-        {
-          "name":"Entertainment 2",
-          "type":"switch",
-          "data": [
-            {
-              "data": "2600500000012...",
-              "sendCount": 2,
-              "interval": 0.3,
-              "pause": 2
-            },
-            {
-              "data": "2600500000012...",
-              "sendCount": 2,
-              "interval": 5
-            }
-          ]
-        },
-        {
-          "name":"Entertainment 3",
-          "type":"switch",
-          "data": {
-            "on": [
-              {
-                "data": "ON_HEX_1...",
-                "pause": 0.3
-              },
-              {
-                "data": "ON_HEX_2...",
-                "sendCount": 2,
-                "interval": 0.1,
-                "pause": 0.3
-              }
-            ],
-            "off": [
-              {
-                "data": "OFF_HEX_1...",
-                "pause": 0.3
-              },
-              {
-                "data": "OF_HEX_2...",
-                "sendCount": 2,
-                "interval": 0.1,
-                "pause": 0.3
-              }
-            ]
-          }
-        },
-        {
-          "name":"Light",
-          "type":"light",
-          "defaultBrightness": 70,
-          "useLastKnownBrightness": true,
-          "enableAutoOff": true,
-          "onDuration": 10,
-          "data":{
-            "off":"2600500000012...",
-            "brightness10": "2600500000012...",
-            "brightness20": "2600500000012...",
-            "brightness30": "2600500000012...",
-            "brightness40": "2600500000012...",
-            "brightness50": "2600500000012...",
-            "brightness60": "2600500000012...",
-            "brightness70": "2600500000012...",
-            "brightness80": "2600500000012...",
-            "brightness90": "2600500000012...",
-            "brightness100": "2600500000012...",
-            "hue0": "2600500000012...",
-            "hue99": "2600500000012...",
-            "hue199": "2600500000012...",
-            "hue299": "2600500000012...",
-            "hue359": "2600500000012..."
-          }
-        },
-        {
-          "name":"Air Conditioner",
-          "type":"air-conditioner",
-          "data":{
-            "off":"2600500000012...",
-            "temperature30":{
-              "pseudo-mode":"heat",
-              "data":"2600500000012..."
-            },
-            "temperature16":{
-              "pseudo-mode":"cool",
-              "data":"2600500000012..."
-            }
-          }
-        },
-        {
-          "name":"Air Conditioner Advanced",
-          "type":"air-conditioner",
-          "autoCoolTemperature": 23,
-          "autoHeatTemperature": 14,
-          "autoSwitch": "A/C Auto Switch",
-          "data":{
-            "off":"2600500000012...",
-            "heat30":{
-              "data":"2600500000012..."
-            },
-            "auto22":{
-              "data":"2600500000012..."
-            },
-            "cool16":{
-              "data":"2600500000012..."
-            }
-          }
-        },
-        {
-          "name":"A/C Auto Switch",
-          "type":"switch"
-        },
-        {
-          "name": "Fan",
-          "type": "fan",
-          "data": {
-            "on":"2600500000012...",
-            "off":"2600500000012...",
-            "swingToggle": "2600500000012...",
-            "fanSpeed10": "2600500000012...",
-            "fanSpeed20": "2600500000012...",
-            "fanSpeed30": "2600500000012...",
-            "fanSpeed40": "2600500000012...",
-            "fanSpeed50": "2600500000012...",
-            "fanSpeed60": "2600500000012...",
-            "fanSpeed70": "2600500000012...",
-            "fanSpeed80": "2600500000012...",
-            "fanSpeed90": "2600500000012...",
-            "fanSpeed100": "2600500000012..."
-          }
-        },
-        {
-          "name":"Garage Door",
-          "type":"garage-door-opener",
-          "openCloseDuration":8,
-          "data":{
-            "open":"2600500000012...",
-            "close":"2600500000012...",
-            "lock":"2600500000012...",
-            "unlock":"2600500000012..."
-          }
-        },
-        {
-          "name":"Blind",
-          "type":"window-covering",
-          "totalDurationOpen": 45,
-          "totalDurationClose": 40,
-          "data":{
-            "open":"2600500000012...",
-            "close":"2600500000012...",
-            "stop":"2600500000012..."
-          }
-        },
-        {
-          "name":"Blind Multi",
-          "type":"window-covering",
-          "totalDurationOpen": 5,
-          "totalDurationClose": 2,
-          "data":{
-            "open":"OPEN_HEX...",
-            "close":[
-              {
-                "data": "CLOSE_HEX_1...",
-                "sendCount": 2,
-                "interval": 0.3,
-                "pause": 0.3
-              },
-              {
-                "data": "CLOSE_HEX_2..."
-              }
-            ],
-            "stop":"STOP_HEX..."
-          }
-        },
-        {
-          "name":"TV",
-          "type":"tv",
-          "data": {
-            "off": "HEX...",
-            "on": "HEX...",
-            "remote": {
-              "select": "HEX...",
-              "arrowUp": "HEX...",
-              "arrowDown": "HEX...",
-              "arrowLeft": "HEX...",
-              "arrowRight": "HEX...",
-              "back": "HEX...",
-              "exit": "HEX...",
-              "playPause": "HEX...",
-              "info": "HEX..."
-            },
-            "powerMode": {
-              "show": "HEX..."
-            },
-            "volume": {
-              "up": "HEX...",
-              "down": "HEX..."
-            },
-            "inputs": [
-              {
-                "name": "INPUT 1",
-                "type": "hdmi",
-                "data": "HEX..."
-              }
-            ]
-          }
-        }
-      ]
-    }
-  ]
+	],
+	"platforms": [{
+		"platform": "BroadlinkRM",
+		"name": "Broadlink RM",
+		"hideScanFrequencyButton": false,
+		"hideLearnButton": false,
+		"hideWelcomeMessage": false,
+		"accessories": [{
+				"name": "Auto-off Switch",
+				"type": "switch",
+				"enableAutoOff": true,
+				"onDuration": 5,
+				"data": {
+					"on": "2600500000012...",
+					"off": "2600500000012..."
+				}
+			},
+			{
+				"name": "TV On/Off",
+				"type": "switch",
+				"data": {
+					"on": "2600500000012...",
+					"off": "2600500000012..."
+				}
+			},
+			{
+				"name": "Entertainment",
+				"type": "switch",
+				"enableAutoOff": true,
+				"onDuration": 1.5,
+				"data": [{
+						"data": "HEX_1...",
+						"pause": 0.3
+					},
+					{
+						"data": "HEX_2...",
+						"pause": 0.3
+					},
+					{
+						"data": "HEX_3...",
+						"pause": 0.3
+					}
+				]
+			},
+			{
+				"name": "Light",
+				"type": "light",
+				"defaultBrightness": 70,
+				"useLastKnownBrightness": true,
+				"enableAutoOff": true,
+				"onDuration": 10,
+				"data": {
+					"off": "2600500000012...",
+					"brightness10": "2600500000012...",
+					"brightness20": "2600500000012...",
+					"brightness30": "2600500000012...",
+					"brightness40": "2600500000012...",
+					"brightness50": "2600500000012...",
+					"brightness60": "2600500000012...",
+					"brightness70": "2600500000012...",
+					"brightness80": "2600500000012...",
+					"brightness90": "2600500000012...",
+					"brightness100": "2600500000012...",
+					"hue0": "2600500000012...",
+					"hue99": "2600500000012...",
+					"hue199": "2600500000012...",
+					"hue299": "2600500000012...",
+					"hue359": "2600500000012..."
+				}
+			},
+      {
+        "name": "LivingRoom Humidity",
+        "type": "humiditySensor"
+      },
+      {
+        "name": "LivingRoom temperature",
+        "type": "temperatureSensor"
+      },
+			{
+				"name": "Air Conditioner",
+				"type": "air-conditioner",
+        "noHumidity": true,
+				"data": {
+					"off": "2600500000012...",
+					"temperature30": {
+						"pseudo-mode": "heat",
+						"data": "2600500000012..."
+					},
+					"temperature16": {
+						"pseudo-mode": "cool",
+						"data": "2600500000012..."
+					}
+				}
+			},
+			{
+				"name": "Air Conditioner Advanced",
+				"type": "air-conditioner",
+				"autoCoolTemperature": 23,
+				"autoHeatTemperature": 14,
+				"autoSwitch": "A/C Auto Switch",
+				"data": {
+					"off": "2600500000012...",
+					"heat30": {
+						"data": "2600500000012..."
+					},
+					"auto22": {
+						"data": "2600500000012..."
+					},
+					"cool16": {
+						"data": "2600500000012..."
+					}
+				}
+			},
+			{
+				"name": "A/C Auto Switch",
+				"type": "switch"
+			},
+			{
+				"name": "Fan",
+				"type": "fan",
+				"data": {
+					"on": "2600500000012...",
+					"off": "2600500000012...",
+					"swingToggle": "2600500000012...",
+					"fanSpeed10": "2600500000012...",
+					"fanSpeed20": "2600500000012...",
+					"fanSpeed30": "2600500000012...",
+					"fanSpeed40": "2600500000012...",
+					"fanSpeed50": "2600500000012...",
+					"fanSpeed60": "2600500000012...",
+					"fanSpeed70": "2600500000012...",
+					"fanSpeed80": "2600500000012...",
+					"fanSpeed90": "2600500000012...",
+					"fanSpeed100": "2600500000012..."
+				}
+			},
+			{
+				"name": "Garage Door",
+				"type": "garage-door-opener",
+				"openCloseDuration": 8,
+				"data": {
+					"open": "2600500000012...",
+					"close": "2600500000012...",
+					"lock": "2600500000012...",
+					"unlock": "2600500000012..."
+				}
+			},
+			{
+				"name": "Blind",
+				"type": "window-covering",
+				"totalDurationOpen": 45,
+				"totalDurationClose": 40,
+				"data": {
+					"open": "2600500000012...",
+					"close": "2600500000012...",
+					"stop": "2600500000012..."
+				}
+			},
+			{
+				"name": "Blind Multi",
+				"type": "window-covering",
+				"totalDurationOpen": 5,
+				"totalDurationClose": 2,
+				"data": {
+					"open": "OPEN_HEX...",
+					"close": [{
+							"data": "CLOSE_HEX_1...",
+							"sendCount": 2,
+							"interval": 0.3,
+							"pause": 0.3
+						},
+						{
+							"data": "CLOSE_HEX_2..."
+						}
+					],
+					"stop": "STOP_HEX..."
+				}
+			},
+			{
+				"name": "TV",
+				"type": "tv",
+				"data": {
+					"off": "HEX...",
+					"on": "HEX...",
+					"remote": {
+						"select": "HEX...",
+						"arrowUp": "HEX...",
+						"arrowDown": "HEX...",
+						"arrowLeft": "HEX...",
+						"arrowRight": "HEX...",
+						"back": "HEX...",
+						"exit": "HEX...",
+						"playPause": "HEX...",
+						"info": "HEX..."
+					},
+					"powerMode": {
+						"show": "HEX..."
+					},
+					"volume": {
+						"up": "HEX...",
+						"down": "HEX..."
+					},
+					"inputs": [{
+						"name": "INPUT 1",
+						"type": "hdmi",
+						"data": "HEX..."
+					}]
+				}
+			},
+			{
+				"name": "Home Theatre",
+				"type": "tv",
+				"subType": "stb",
+				"pingIPAddress": "192.168.1.5",
+				"pingFrequency": 5,
+				"pingIPAddressStateOnly": true,
+				"pingGrace": 15,
+				"data": {
+					"on": "HEX...",
+					"off": "HEX...",
+					"remote": {
+						"select": "HEX...",
+						"arrowUp": "HEX...",
+						"arrowDown": "HEX...",
+						"arrowLeft": "HEX...",
+						"arrowRight": "HEX...",
+						"back": "HEX...",
+						"playPause": "HEX...",
+						"exit": "HEX...",
+						"info": "HEX..."
+					},
+					"volume": {
+						"up": "HEX...",
+						"down": "HEX..."
+					},
+					"inputs": [{
+							"name": "Function",
+							"type": "hdmi",
+							"data": "HEX..."
+						},
+						{
+							"name": "Optical",
+							"type": "other",
+							"data": "HEX..."
+						},
+						{
+							"name": "Home",
+							"type": "other",
+							"data": "HEX..."
+						}
+					]
+				}
+			}
+		]
+	}]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-broadlink-rm-pro",
-  "version": "4.3.2",
+  "version": "4.3.3-beta.5",
   "description": "Broadlink RM plugin (including the mini and pro) for homebridge with AC Pro and TV features",
   "license": "ISC",
   "scripts": {
@@ -25,11 +25,11 @@
     "url": "git@github.com:kiwi-cam/homebridge-broadlink-rm.git"
   },
   "dependencies": {
-    "kiwicam-broadlinkjs-rm": "^0.9.1",
+    "kiwicam-broadlinkjs-rm": "^0.9.2-beta.2",
     "chai": "^4.1.2",
     "find-key": "^2.0.1",
     "github-version-checker": "^1.2.0",
-    "homebridge-platform-helper": "1.1.1",
+    "homebridge-platform-helper": "^1.2.1",
     "ping": "^0.2.2",
     "uuid": "^3.2.1",
     "compare-versions": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-broadlink-rm-pro",
-  "version": "4.3.3-beta.5",
+  "version": "4.3.3",
   "description": "Broadlink RM plugin (including the mini and pro) for homebridge with AC Pro and TV features",
   "license": "ISC",
   "scripts": {
@@ -25,7 +25,7 @@
     "url": "git@github.com:kiwi-cam/homebridge-broadlink-rm.git"
   },
   "dependencies": {
-    "kiwicam-broadlinkjs-rm": "^0.9.2-beta.2",
+    "kiwicam-broadlinkjs-rm": "^0.9.2",
     "chai": "^4.1.2",
     "find-key": "^2.0.1",
     "github-version-checker": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "git@github.com:kiwi-cam/homebridge-broadlink-rm.git"
   },
   "dependencies": {
-    "kiwicam-broadlinkjs-rm": "^0.9.2",
+    "kiwicam-broadlinkjs-rm": "latest",
     "chai": "^4.1.2",
     "find-key": "^2.0.1",
     "github-version-checker": "^1.2.0",

--- a/platform.js
+++ b/platform.js
@@ -10,6 +10,8 @@ const { createAccessory } = require('./helpers/accessoryCreator');
 
 const classTypes = {
   'air-conditioner': Accessory.AirCon,
+  'air-purifier': Accessory.AirPurifier,
+  'humidifier-dehumidifier': Accessory.HumidifierDehumidifier,
   'learn-ir': Accessory.LearnCode,
   'learn-code': Accessory.LearnCode,
   'switch': Accessory.Switch,
@@ -21,8 +23,11 @@ const classTypes = {
   'fan': Accessory.Fan,
   'outlet': Accessory.Outlet,
   'light': Accessory.Light,
+  'window': Accessory.Window,
   'window-covering': Accessory.WindowCovering,
-  'tv': Accessory.TV
+  'tv': Accessory.TV,
+  'temperatureSensor': Accessory.TemperatureSensor,
+  'humiditySensor': Accessory.HumiditySensor
 }
 
 let homebridgeRef
@@ -72,7 +77,7 @@ const BroadlinkRMPlatform = class extends HomebridgePlatform {
         if(accessory.subType.toLowerCase() === 'stb'){homeKitAccessory.subType = homebridgeRef.hap.Accessory.Categories.TV_SET_TOP_BOX;}
         if(accessory.subType.toLowerCase() === 'receiver'){homeKitAccessory.subType = homebridgeRef.hap.Accessory.Categories.AUDIO_RECEIVER;}
         if(accessory.subType.toLowerCase() === 'stick'){homeKitAccessory.subType = homebridgeRef.hap.Accessory.Categories.TV_STREAMING_STICK;}
-        
+
         if (debug) log(`\x1b[34m[DEBUG]\x1b[0m Adding Accessory ${accessory.type} (${accessory.subType})`);
         tvs.push(homeKitAccessory);
         return;
@@ -95,7 +100,7 @@ const BroadlinkRMPlatform = class extends HomebridgePlatform {
         log(`**************************************************************************************************************`);
         log('');
       }
-    } 
+    }
   }
 
   discoverBroadlinkDevices () {
@@ -108,16 +113,16 @@ const BroadlinkRMPlatform = class extends HomebridgePlatform {
 
       return;
     }
-    
+
     discoverDevices(false, log, debug);
 
     log(`\x1b[35m[INFO]\x1b[0m Automatic Broadlink RM device discovery has been disabled as the "hosts" option has been set.`)
 
     assert.isArray(hosts, `\x1b[31m[CONFIG ERROR] \x1b[33mhosts\x1b[0m should be an array of objects.`)
-      
+
     hosts.forEach((host) => {
       assert.isObject(host, `\x1b[31m[CONFIG ERROR] \x1b[0m Each item in the \x1b[33mhosts\x1b[0m array should be an object.`)
-      
+
       const { address, isRFSupported, mac } = host;
       assert(address, `\x1b[31m[CONFIG ERROR] \x1b[0m Each object in the \x1b[33mhosts\x1b[0m option should contain a value for \x1b[33maddress\x1b[0m (e.g. "192.168.1.23").`)
       assert(mac, `\x1b[31m[CONFIG ERROR] \x1b[0m Each object in the \x1b[33mhosts\x1b[0m option should contain a unique value for \x1b[33mmac\x1b[0m (e.g. "34:ea:34:e7:d7:28").`)


### PR DESCRIPTION
If not using `swingMode` there is no need for Fanv2.

This also partially solves https://github.com/kiwi-cam/homebridge-broadlink-rm/issues/74 as using Service.Fan allows the icon to be changed in the Home app.

I'm looking into if there is an underlying Homebridge or Hap-NodeJS issue that can be fixed to allow Service.Fanv2 have a changeable icon, but this fix for your library will still be relevant even if it is fixed for Service.Fanv2 somewhere else.