### PR TITLE
Add package display name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "homebridge-broadlink-rm-pro",
+  "displayName": "Homebridge Broadlink RM Pro",
   "version": "4.4.6",
   "description": "Broadlink RM plugin (including the mini and pro) for homebridge with AC Pro and TV features",
   "license": "ISC",


### PR DESCRIPTION
This pull request adds a display name so that it displays as "Homebridge Broadlink RM Pro" instead of "Homebridge Broadlink Rm Pro" in [Homebridge UI](https://github.com/oznu/homebridge-config-ui-x).