### PR TITLE
Make sure manual devices are discovered

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -137,7 +137,7 @@ const BroadlinkRMPlatform = class extends HomebridgePlatform {
     })
   }
 
-  tryAddDeviceFromHosts(host, macAddress, deviceType, log ) {
+  tryAddDeviceFromHosts(host, macAddress, deviceType, log) {
     // will close the socket and remove the device, could live on the kiwicam-broadlinkjs-rm module itself
     if (broadlink.devices[macAddress]) {
       if (broadlink.devices[macAddress].socket) {


### PR DESCRIPTION
Hey, thanks for keeping this plugin alive. I have an issue where I have multiple broadlink devices that I specify manually, the problem is that if at the time of Homebridge start up an RM device is not online - homebridge needs rebooting so that manual devices can be added, which annoys the hell out of me.

This little code change just make it infinitely retry to add manual devices until they are operating (with 5 second delay between tries). 

Let me know if I need to change anything or if you have any questions. Cheers. 