### PR TITLE
Turns off other lights in group when it turns on.

### DIFF
--- a/accessories/light.js
+++ b/accessories/light.js
@@ -1,4 +1,3 @@
-// -*- js-indent-level : 2 -*-
 const { assert } = require('chai');
 const ServiceManagerTypes = require('../helpers/serviceManagerTypes');
 const delayForDuration = require('../helpers/delayForDuration');
@@ -7,10 +6,10 @@ const catchDelayCancelError = require('../helpers/catchDelayCancelError')
 const SwitchAccessory = require('./switch');
 
 class LightAccessory extends SwitchAccessory {
-    
+
   setDefaults () {
     super.setDefaults();
-    
+  
     const { config } = this;
 
     config.onDelay = config.onDelay || 0.1;
@@ -46,15 +45,10 @@ class LightAccessory extends SwitchAccessory {
 	    exAccessory.exclusives.push(this);
 	  }
 	} else {
-	  log(`${name} No accessory could be found with the name "${exName}". Please update the "exclusives" value or add a matching switch accessory.`);
+	  log(`${name} No accessory could be found with the name "${exName}". Please update the "exclusives" value or add matching light accessories.`);
 	}
       });
     }
-    //console.log(this.exclusives);
-
-    // if (autoSwitchAccessories.length === 0) {return log(`${name} No accessory could be found with the name "${autoSwitchName}". Please update the "autoSwitchName" value or add a matching switch accessory.`);}
-
-    // this.autoSwitchAccessory = autoSwitchAccessories[0];
   }
 
   async setSwitchState (hexData, previousValue) {
@@ -80,7 +74,7 @@ class LightAccessory extends SwitchAccessory {
         log(`${name} setSwitchState: (brightness: ${brightness})`);
 
         //state.switchState = false;
-        this.state.brightness = brightness;
+        state.brightness = brightness;
         serviceManager.setCharacteristic(Characteristic.Brightness, brightness);
       } else {
         if (hexData) {await this.performSend(hexData);}
@@ -110,8 +104,7 @@ class LightAccessory extends SwitchAccessory {
 
       if (!state.switchState) {
 
-        //state.switchState = true;
-        this.state.switchState = true;
+        state.switchState = true;
         serviceManager.refreshCharacteristicUI(Characteristic.On);
 
         if (on) {
@@ -149,8 +142,7 @@ class LightAccessory extends SwitchAccessory {
       if (this.lastBrightness === state.brightness) {
 
         if (state.brightness > 0) {
-          //state.switchState = true;
-          this.state.switchState = true;
+          state.switchState = true;
         }
 
         await this.checkAutoOnOff();
@@ -164,8 +156,7 @@ class LightAccessory extends SwitchAccessory {
 
       if (state.brightness > 0) {
         if (!state.switchState) {
-          //state.switchState = true;
-          this.state.switchState = true;
+          state.switchState = true;
           serviceManager.refreshCharacteristicUI(Characteristic.On);
     
           if (on) {

--- a/accessories/light.js
+++ b/accessories/light.js
@@ -35,7 +35,7 @@ class LightAccessory extends SwitchAccessory {
       exclusives.forEach(exname => {
 	const exAccessory = accessories.find(x => x.name === exname);
 	//console.log(exAccessory.name);
-	if (exAccessory) {
+	if (exAccessory && exAccessory.config.type === 'light') {
 	  if (!this.exclusives) this.exclusives = [];
 	  if (!this.exclusives.find(x => x === exAccessory)) {
 	    this.exclusives.push(exAccessory);
@@ -45,7 +45,7 @@ class LightAccessory extends SwitchAccessory {
 	    exAccessory.exclusives.push(this);
 	  }
 	} else {
-	  log(`${name} No accessory could be found with the name "${exName}". Please update the "exclusives" value or add matching light accessories.`);
+	  log(`${name}: No light accessory could be found with the name "${exname}". Please update the "exclusives" value or add matching light accessories.`);
 	}
       });
     }

--- a/accessories/light.js
+++ b/accessories/light.js
@@ -73,8 +73,7 @@ class LightAccessory extends SwitchAccessory {
       if (brightness !== state.brightness || previousValue !== state.switchState) {
         log(`${name} setSwitchState: (brightness: ${brightness})`);
 
-        //state.switchState = false;
-        state.brightness = brightness;
+        state.switchState = false;
         serviceManager.setCharacteristic(Characteristic.Brightness, brightness);
       } else {
         if (hexData) {await this.performSend(hexData);}


### PR DESCRIPTION
Hi kiwi-cam,

Your plug-in makes my life better and better. Thank you very much.  And I wrote small patch to make it more better.

This patch add a function to turn OFF the other lights in a group when it turns ON.

 Let's take an example light bulb which has light-mode and nightlight-mode. These two modes can be configured as two separate accessories using this plug-in. They can be turned ON individually.

 However, if switch to light-mode (light accessory ON) to nightlight-mode (night-light accessory ON ), both accessories are ON in HOME app, and are different from physical situation. This patch enables to turns off light accessory in this scenario  with defining these two accessories as a group. If one of light in the group will turn ON, the others in the group will turn OFF.
Following config defines such group using keyword "exclusives".

{"name": "light", "type": "light", "exclusives": ["nightlight"], ... },
{"name": "nightlight", "type": "light", ... },

To implement this function, all added codes are enclosed by presence of above keyword, thus it won't affect existing functionaries or users.  If you have interests in this function, I hope it will be integrated to your plug-in.

Thanks in advance. 
