### PR TITLE
Enables mode & targetTemperature histories in EVE

### DIFF
--- a/accessories/aircon.js
+++ b/accessories/aircon.js
@@ -828,7 +828,7 @@ class AirConAccessory extends BroadlinkRMAccessory {
     config.enableModeHistory = config.enableModeHistory === true || config.enableTargetTemperatureHistory === true || false;
     if (config.noHistory !== true) {
       if (config.enableTargetTemperatureHistory === true) {
-	this.log(`${this.name} Accessory is configured to record HeatingCoolingState and targetTemperature history.`);
+	this.log(`${this.name} Accessory is configured to record HeatingCoolingState and targetTemperature histories.`);
       } else if (config.enableModeHistory === true) {
 	this.log(`${this.name} Accessory is configured to record HeatingCoolingState history.`);
       }

--- a/accessories/aircon.js
+++ b/accessories/aircon.js
@@ -8,6 +8,8 @@ const ServiceManagerTypes = require('../helpers/serviceManagerTypes');
 const catchDelayCancelError = require('../helpers/catchDelayCancelError');
 const { getDevice } = require('../helpers/getDevice');
 const BroadlinkRMAccessory = require('./accessory');
+const eveHistoryType = 'custom';
+const enableTagetTemperatureHistory = true;
 
 class AirConAccessory extends BroadlinkRMAccessory {
 
@@ -34,14 +36,44 @@ class AirConAccessory extends BroadlinkRMAccessory {
     
     // Fakegato setup
     if(config.noHistory !== true) {
+      this.services = this.getServices();
       this.displayName = config.name;
       this.lastUpdatedAt = undefined;
-      this.historyService = new HistoryService("room", this, { storage: 'fs', filename: 'RMPro_' + config.name.replace(' ','-') + '_persist.json'});
+      //this.historyService = new HistoryService("room", this, { storage: 'fs', filename: 'RMPro_' + config.name.replace(' ','-') + '_persist.json'});
+      //this.historyService = new HistoryService("thermo", this, { storage: 'fs', filename: 'RMPro_' + config.name.replace(' ','-') + '_persist.json'});
+      this.historyService = new HistoryService(eveHistoryType, this, { storage: 'fs', filename: 'RMPro_' + config.name.replace(' ','-') + '_persist.json'});
       this.historyService.log = this.log;  
+
+      if (eveHistoryType == 'custom') {
+	let state2 = this.state;
+	//console.log(state2)
+	this.state = new Proxy(state2, {
+	  set: function(target, key, value) {
+	    if (target[key] != value) {
+	      Reflect.set(target, key, value);
+	      if (this.historyService) {
+		if (key == `targetTemperature`) {
+		  this.log.debug(`adding history of targetTemperature.`, value)
+		  this.historyService.addEntry(
+		    {time: Math.round(new Date().valueOf()/1000),
+		     setTemp: value || 30})
+		} else if (key == 'targetHeatingCoolingState') {
+		  this.log.debug(`adding history of targetHeatingCoolingState.`, value * 25)
+		  this.historyService.addEntry(
+		    {time: Math.round(new Date().valueOf()/1000),
+		     valvePosition: value * 25})
+		}
+	      }
+	    }
+	    return true
+	  }.bind(this)
+	})
+      }
     }
 
     this.temperatureCallbackQueue = {};
     this.monitorTemperature();
+    this.thermoHistory();
   }
 
   correctReloadedState (state) {
@@ -424,6 +456,21 @@ class AirConAccessory extends BroadlinkRMAccessory {
     this.processQueuedTemperatureCallbacks(temperature);
   }
 
+  async thermoHistory() { 
+    const {config} = this;
+    if (config.noHistory !== true && eveHistoryType === 'custom') {
+      this.historyService.addEntry({
+	time: Math.round(new Date().valueOf() / 1000),
+	setTemp: this.state.targetTemperature, 
+	valvePosition: this.state.targetHeatingCoolingState * 25
+      });
+      
+      setTimeout(() => {
+	this.thermoHistory();
+      }, 10 * 60 * 1000);
+    }
+  }
+
   addTemperatureCallbackToQueue (callback) {
     const { config, host, logLevel, log, name, state } = this;
     const { mqttURL, temperatureFilePath, w1DeviceID, noHumidity } = config;
@@ -741,12 +788,97 @@ class AirConAccessory extends BroadlinkRMAccessory {
     this.onTemperature(this.mqttValues.temperature,this.mqttValues.humidity);
   }
 
+  getValvePosition(callback) {
+    // not implemented
+    //console.log('getValvePosition() is requested.', this.displayName);
+    callback(null, this.state.targetHeatingCoolingState * 25);
+  }
+  
+  setProgramCommand(value, callback) {
+    // not implemented
+    //console.log('setProgramCommand() is requested. %s', value, this.displayName);
+    callback();
+  }
+  
+  getProgramData(callback) {
+    // not implemented
+    //    var data  = "12f1130014c717040af6010700fc140c170c11fa24366684ffffffff24366684ffffffff24366684ffffffff24366684ffffffff24366684ffffffff24366684ffffffff24366684fffffffff42422222af3381900001a24366684ffffffff";
+    var data  = "ff04f6";
+    var buffer = new Buffer.from(('' + data).replace(/[^0-9A-F]/ig, ''), 'hex').toString('base64');
+    //console.log('getProgramData() is requested. (%s)', buffer, this.displayName);
+    callback(null, buffer);
+  }
+
+  localCharacteristic(key, uuid, props) {
+    let characteristic = class extends Characteristic {
+      constructor() {
+	super(key, uuid);
+	this.setProps(props);
+      }
+    }
+    characteristic.UUID = uuid;
+
+    return characteristic;
+  }
+
   // Service Manager Setup
 
   setupServiceManager () {
     const { config, name, serviceManagerType } = this;
 
     this.serviceManager = new ServiceManagerTypes[serviceManagerType](name, Service.Thermostat, this.log);
+
+    if(config.noHistory !== true && eveHistoryType === 'custom') {
+      const ValvePositionCharacteristic = this.localCharacteristic(
+	'ValvePosition', 'E863F12E-079E-48FF-8F27-9C2605A29F52',
+	{format: Characteristic.Formats.UINT8,
+	 unit: Characteristic.Units.PERCENTAGE,
+	 perms: [
+           Characteristic.Perms.READ,
+           Characteristic.Perms.NOTIFY
+	 ]});
+
+      this.serviceManager.addGetCharacteristic({
+	name: 'currentValvePosition',
+	//type: eve.Characteristics.ValvePosition,
+	type: ValvePositionCharacteristic,
+	method: this.getValvePosition,
+	bind: this
+      });
+      
+      if (enableTagetTemperatureHistory) {
+	const ProgramDataCharacteristic = this.localCharacteristic(
+	  'ProgramData', 'E863F12F-079E-48FF-8F27-9C2605A29F52',
+	  {format: Characteristic.Formats.DATA,
+	   perms: [
+             Characteristic.Perms.READ,
+             Characteristic.Perms.NOTIFY
+	   ]});
+	
+	const ProgramCommandCharacteristic = this.localCharacteristic(
+	  'ProgramCommand', 'E863F12C-079E-48FF-8F27-9C2605A29F52',
+	  {format: Characteristic.Formats.DATA,
+	   perms: [
+             Characteristic.Perms.WRITE
+	   ]});
+	
+	this.serviceManager.addGetCharacteristic({
+	  name: 'setProgramData',
+	  //type: eve.Characteristics.ProgramData,
+	  type: ProgramDataCharacteristic,
+	  method: this.getProgramData,
+	  bind: this,
+	});
+	
+	this.serviceManager.addSetCharacteristic({
+	  name: 'setProgramCommand',
+	  //type: eve.Characteristics.ProgramCommand,
+	  type: ProgramCommandCharacteristic,
+	  method: this.setProgramCommand,
+	  bind: this,
+	});
+      }
+    }
 
     this.serviceManager.addToggleCharacteristic({
       name: 'currentHeatingCoolingState',

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node-persist": ">=2.1.0 <3.0.0",
     "semver": "^7.3.4",
     "node-arp": "^1.0.6",
-    "fakegato-history": "^0.6.2"
+    "fakegato-history": "^0.6.3"
   },
   "devDependencies": {
     "eslint": "^8.3.0",


### PR DESCRIPTION
Hi Kiwi-cam.

This 3rd. patch enables mode and targetTemperature histories in EVE for air-conditioner accessory. Please look attached screenshots of EVE. Compared to current(AC0), AC1 shows mode history, and AC2 shows targetTemperature history. These features require newer version of fakegato-history (0.6.3), and enabled by following two new config keywords of air-conditioner.

1. enableModeHistory
  Default is false, and false keeps conventional logging function as shown in AC0. Setting to true enables EVE to show  targetHeatingCoolingState history in addition  to temperature and humidity histories as shown in AC1.

2. enableTergetTemperatureHistory
  Default is false. Setting to true sets enableModeHistory to true internally, and enables EVE to show targetTemperature and targetHeatingCoolingState histories in addition  to temperature and humidity histories as shown in AC2. Unfortunately, EVE misses mode control function and this is a reason of two separate modes are implemented.

Note that creating new accessory is highly recommended to exam these features. Logging information are different, and may cause unexpected results or logging file corruption due to incompatibility.  

Also note that logging information are identical despite of above two modes. These modes only switch characteristics to be seen by EVE.  

If you will have interests, I hope these features are integrated to your plug-in.

Thanks in advance.

![conventional](https://user-images.githubusercontent.com/98196664/153303087-016f2999-99ac-45ce-b310-333d1027e332.PNG)
![enableModeHIstory](https://user-images.githubusercontent.com/98196664/153303084-bc9849ee-1088-4a5a-bd5d-d61822e5bb7e.PNG)
![enableTargetTemperatureHistory](https://user-images.githubusercontent.com/98196664/153303086-d0524464-0eed-4228-90dc-093ea1bd15c3.PNG)

