### PR TITLE
Eliminates redundant unreachable messages of RM devices.

### DIFF
--- a/helpers/getDevice.js
+++ b/helpers/getDevice.js
@@ -34,16 +34,22 @@ const startPing = (device, log) => {
         }
         
         if (!active && device.state === 'active' && retryCount === 2) {
-          log(`Broadlink RM device at ${device.host.address} (${device.host.macAddress || ''}) is no longer reachable after three attempts.`);
+	  if (!broadlink.accessories || broadlink.accessories.find((x) => x.host === undefined || x.host === device.host.address || x.host === device.host.macAddress)) {
+            log(`Broadlink RM device at ${device.host.address} (${device.host.macAddress || ''}) is no longer reachable after three attempts.`);
+	  }
 
           device.state = 'inactive';
           retryCount = 0;
         } else if (!active && device.state === 'active') {
-          if(broadlink.debug) {log(`Broadlink RM device at ${device.host.address} (${device.host.macAddress || ''}) is no longer reachable. (attempt ${retryCount})`);}
+	  if (!broadlink.accessories || broadlink.accessories.find((x) => x.host === undefined || x.host === device.host.address || x.host === device.host.macAddress)) {
+	    if(broadlink.debug) {log(`Broadlink RM device at ${device.host.address} (${device.host.macAddress || ''}) is no longer reachable. (attempt ${retryCount})`);}
+	  }
 
           retryCount += 1;
         } else if (active && device.state !== 'active') {
-          if (device.state === 'inactive') {log(`Broadlink RM device at ${device.host.address} (${device.host.macAddress || ''}) has been re-discovered.`);}
+	  if (!broadlink.accessories || broadlink.accessories.find((x) => x.host === undefined || x.host === device.host.address || x.host === device.host.macAddress)) {
+            if (device.state === 'inactive') {log(`Broadlink RM device at ${device.host.address} (${device.host.macAddress || ''}) has been re-discovered.`);}
+	  }
 
           device.state = 'active';
           retryCount = 0;
@@ -62,9 +68,10 @@ const discoveredDevices = {};
 const manualDevices = {};
 let discoverDevicesInterval;
 
-const discoverDevices = (automatic = true, log, logLevel, deviceDiscoveryTimeout = 60) => {
+const discoverDevices = (automatic = true, log, logLevel, deviceDiscoveryTimeout = 60, accessories = null) => {
   broadlink.log = log;
   broadlink.debug = logLevel <=1;
+  broadlink.accessories = accessories;
   //broadlink.logLevel = logLevel;
 
   if (automatic) {

--- a/helpers/sendData.js
+++ b/helpers/sendData.js
@@ -28,7 +28,7 @@ module.exports = ({ host, hexData, log, name, logLevel }) => {
   if (!device.sendData) {return log(`\x1b[31m[ERROR] \x1b[0mThe device at ${device.host.address} (${device.host.macAddress}) doesn't support the sending of IR or RF codes.`);}
   if (hexData.includes('5aa5aa555')) {return log(`\x1b[31m[ERROR] \x1b[0mThis type of hex code (5aa5aa555...) is no longer valid. Use the included "Learn Code" accessory to find new (decrypted) codes.`);}
 
-  const hexDataBuffer = new Buffer(hexData, 'hex');
+  const hexDataBuffer = new Buffer.from(hexData, 'hex');
   device.sendData(hexDataBuffer, logLevel, hexData);
 
   if (logLevel <=2) {log(`${name} sendHex (${device.host.address}; ${device.host.macAddress}) ${hexData}`);}

--- a/platform.js
+++ b/platform.js
@@ -110,7 +110,7 @@ const BroadlinkRMPlatform = class extends HomebridgePlatform {
 
     if (!hosts) {
       if (logLevel <=2) {log(`\x1b[35m[INFO]\x1b[0m Automatically discovering Broadlink RM devices.`)}
-      discoverDevices(true, log, logLevel, config.deviceDiscoveryTimeout);
+	discoverDevices(true, log, logLevel, config.deviceDiscoveryTimeout, config.accessories);
 
       return;
     }


### PR DESCRIPTION
This patch is intended to reduce unreachable messages of RM devices in log, and hopefully applied together with former patch #459. 

Background:
My network consists of few distant sub-networks. Each sub-network has its own homebridge instance and are including RM devices in their locations. Thanks to this plug-in, these RM devices are automatically discovered and network reachability are probed. However, unreachability reports of another sub-network devices are not interested and redundant. 

The purpose of this patch:
The detected unreachable devices are confirmed their presence in host section of each accessory in config. If the device was found or any accessories in config don't include host section (default host configuration) the messages will be reported, otherwise will be ignored. 

This patch also fixes buffer() vulnerability in helpers/sendData.js.
