### PR TITLE
Extended MQTT message handler to sync statuses between plug-ins.

### DIFF
--- a/accessories/aircon.js
+++ b/accessories/aircon.js
@@ -682,8 +682,8 @@ class AirConAccessory extends BroadlinkRMAccessory {
     }
 
     if (identifier.toLowerCase() === 'targettemperature' ||
-	identifier.toLowerCase() === 'targetcoolingthresholdtemperature' ||
-	identifier.toLowerCase() === 'targetheatingthresholdtemperature') {
+	identifier.toLowerCase() === 'coolingthresholdtemperature' ||
+	identifier.toLowerCase() === 'heatingthresholdtemperature') {
       let target = parseInt(this.mqttValuesTemp[identifier].match(/^([0-9]+)$/g));
       if (target > 0 && target >= config.minTemperature && target <= config.maxTemperature) {
 	if (mqttStateOnly) {


### PR DESCRIPTION
Hi kiwi-cam and developers.

Until recently, I didn't have much interests in MQTT since I don't have such devices. But from the recent and past discussions in issues, I thought that it can be used for a communication way  between plug-ins. So I experimentally implemented a function to sync accessory statuses of air-conditioners as POC. Thanks to original author's (lprhodes's) smart designing basis, the implementation was not so hard, and is working well in my environment.

This PR is intended to share the POC and my thoughts of implementation.

1. identifier
To clarify the behavior, the Identifier string should be a HAP characteristic and the alternatives are defined as variation. In this implementation I use 'currentheatingcoolingstate' and 'currentheatercoolerstate' for the operating status of air-conditioner, and  'mode' as an alternative. 'targettemperature', 'coolingthresholdtemperature' and 'heatingthresholdtemperature' for the target temperature  of air-conditioner.

2. topic message
The message of each topic shouldn't be an 'object', but should be a 'string'. As in current implementations of temperature/humidity/battery, allowing object format makes the semantic very ambiguous, and the codes are likely to be messy. In such cases, the object format messages should be divided into unique-topic/string-message pairs by external process, I believe. In this implementation, the message value of 'mode' identifier can be one of 'off', 'heat', 'cool', 'auto', and integer for 'targettemperature'  identifier.

3. status update only
In this implementation, I introduced a config keyword 'mqttStateOnly'.  On receiving a MQTT message, like a pingIPAddressStateOnly in 'switch' accessory, setting true will only updates the accessory status. Setting false will trigger the accessory operation (i.e. will send IR codes). The default is true.