### PR TITLE
New version message now logged to console properly + prereleases excluded

### DIFF
--- a/helpers/checkForUpdates.js
+++ b/helpers/checkForUpdates.js
@@ -8,11 +8,10 @@ const options = {
 };
 
 
-const checkForUpdates = () => {
+const checkForUpdates = (log) => {
   versionCheck (options, (error, update) => { 
-    // if (error) throw error;
     if (update) { 
-      console.log(`\x1b[32m[UPDATE AVAILABLE] \x1b[0mVersion ${update.name} of Homebridge Broadlink RM Pro is available. The release notes can be found here: \x1b[4mhttps://github.com/${options.owner}/homebridge-broadlink-rm/releases/\x1b[0m`);
+      log(`\x1b[32m[UPDATE AVAILABLE] \x1b[0mVersion ${update.name} of Homebridge Broadlink RM Pro is available. The release notes can be found here: \x1b[4mhttps://github.com/${options.owner}/homebridge-broadlink-rm/releases/\x1b[0m`);
     }
   });
 }

--- a/helpers/checkForUpdates.js
+++ b/helpers/checkForUpdates.js
@@ -4,7 +4,8 @@ const pkg = require('../package.json');
 const options = {
   repo: 'homebridge-broadlink-rm', 
   owner: 'kiwi-cam',
-  currentVersion: pkg.version
+  currentVersion: pkg.version,
+  excludePrereleases: true
 };
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1700,9 +1700,9 @@
       "integrity": "sha1-1ayswxu59rd+XFAoEukMhE9ye8o="
     },
     "github-version-checker": {
-      "version": "2.2.0",
-      "resolved": false,
-      "integrity": "sha512-Ttj/Uzg++TGfycfn5ga8BfMJ8QYB1+DhG24rtasrN8tHYWgqqrEMAQ52y2qGnPNWzSF8AUdjm6dBcoPdUhKhDQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/github-version-checker/-/github-version-checker-2.3.0.tgz",
+      "integrity": "sha512-JAAB8Q/U+HkZHpBail8c28wS6zgWV3k1kK7FiWzMFW5NyVt74K1hZffoJgFHXZpFdZl/VIQm8K2wdl/C1CA/DA==",
       "requires": {
         "github-graphql-client": "^1.0.0",
         "semver": "^5.5.1"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "kiwicam-broadlinkjs-rm": "^0.9.16",
     "chai": "^4.2.0",
     "find-key": "^2.1.3",
-    "github-version-checker": "^2.2.0",
+    "github-version-checker": "^2.3.0",
     "ping": "^0.3.0",
     "uuid": "^8.3.2",
     "compare-versions": "^3.6.0",

--- a/platform.js
+++ b/platform.js
@@ -45,7 +45,7 @@ const BroadlinkRMPlatform = class extends HomebridgePlatform {
 
     this.discoverBroadlinkDevices();
     this.showMessage();
-    setTimeout(checkForUpdates, 1800);
+    setTimeout(function() {checkForUpdates(log);}, 1800);
 
     if (!config.accessories) {config.accessories = []}
 


### PR DESCRIPTION
Previously the new version message was not logged properly and also alerted regarding prerelease version. This fixes both of these issue.