### PR TITLE
[air-conditioner] Support accurate Fahrenheit set points

### DIFF
--- a/helpers/flexibleTemperatureDataUtils.js
+++ b/helpers/flexibleTemperatureDataUtils.js
@@ -1,0 +1,42 @@
+function extractMaybeTemperatureStrings(data, prefix) {
+  return Object.keys(data)
+    .filter(k => k.startsWith(prefix))
+    .map(k => k.substring(prefix.length));
+}
+
+function extractFloats(data, prefix) {
+  return extractMaybeTemperatureStrings(data, prefix)
+    .map(parseFloat)
+    .filter(num => `${prefix}${num}` in data);
+}
+
+function hasGranularTemperatures(data, prefixes) {
+  return prefixes
+    .flatMap(prefix => extractMaybeTemperatureStrings(data, prefix))
+    .some(s => s.includes('.'));
+}
+
+function lookup(data, prefix, temperature) {
+  const knownTemperatures = extractFloats(data, prefix);
+  if (knownTemperatures.length === 0) {
+    return null;
+  }
+
+  const closestKnownTemperature = knownTemperatures
+    .reduce(function (prev, curr) {
+      return (Math.abs(curr - temperature) < Math.abs(prev - temperature) ? curr : prev);
+    });
+
+  if (Math.abs(closestKnownTemperature - temperature) < 1) {
+    return data[`${prefix}${closestKnownTemperature}`];
+  }
+
+  return null;
+}
+
+module.exports = {
+  extractMaybeTemperatureStrings,
+  extractFloats,
+  hasGranularTemperatures,
+  lookup,
+}

--- a/test/flexibleTemperature.test.js
+++ b/test/flexibleTemperature.test.js
@@ -1,0 +1,208 @@
+const { expect } = require('chai');
+
+const { extractMaybeTemperatureStrings, extractFloats, hasGranularTemperatures, lookup } = require('../helpers/flexibleTemperatureDataUtils.js');
+
+describe('extractMaybeTemperatureStrings', () => {
+  it('reads all digits', () => {
+    expect(extractMaybeTemperatureStrings({
+      on: 'ON',
+      off: 'OFF',
+      temperature16: {
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_16'
+      },
+      temperature18: {
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_18'
+      },
+      temperature23: {
+        'pseudo-mode': 'heat',
+        'data': 'TEMPERATURE_23'
+      },
+    }, 'temperature')).to.eql(['16', '18', '23']);
+  })
+
+  it('reads digits and a dot', () => {
+    expect(extractMaybeTemperatureStrings({
+      on: 'ON',
+      off: 'OFF',
+      'temperature21.1': {
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_70F'
+      },
+      'temperature21.7': {
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_71F'
+      },
+      'temperature22.2': {
+        'pseudo-mode': 'heat',
+        'data': 'TEMPERATURE_72F'
+      },
+    }, 'temperature')).to.eql(['21.1', '21.7', '22.2']);
+  })
+});
+
+describe('extractFloats', () => {
+  it('parses all digits', () => {
+    expect(extractFloats({
+      on: 'ON',
+      off: 'OFF',
+      temperature16: {
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_16'
+      },
+      temperature18: {
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_18'
+      },
+      temperature23: {
+        'pseudo-mode': 'heat',
+        'data': 'TEMPERATURE_23'
+      },
+    }, 'temperature')).to.eql([16, 18, 23]);
+  })
+
+  it('parses digits with a decimal point', () => {
+    expect(extractFloats({
+      on: 'ON',
+      off: 'OFF',
+      'temperature21.1': {
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_70F'
+      },
+      'temperature21.7': {
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_71F'
+      },
+      'temperature22.2': {
+        'pseudo-mode': 'heat',
+        'data': 'TEMPERATURE_72F'
+      },
+    }, 'temperature')).to.eql([21.1, 21.7, 22.2]);
+  })
+
+  it('disregards fuzzy values', () => {
+    expect(extractFloats({
+      on: 'ON',
+      off: 'OFF',
+      'temperature 21.1': { // has a space in the middle; should be ignored
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_70F'
+      },
+      'temperature21.7 ': { // has a space in the end; should be ignored
+        'pseudo-mode': 'cool',
+        'data': 'TEMPERATURE_71F'
+      },
+      'temperature22.2': {
+        'pseudo-mode': 'heat',
+        'data': 'TEMPERATURE_72F'
+      },
+    }, 'temperature')).to.eql([/* 21.1, 21.7, */ 22.2]);
+  })
+});
+
+describe('hasGranularTemperatures', () => {
+  const data = {
+    on: 'ON',
+    off: 'OFF',
+    temperature16: {
+      'pseudo-mode': 'cool',
+      'data': 'TEMPERATURE_16'
+    },
+    temperature18: {
+      'pseudo-mode': 'cool',
+      'data': 'TEMPERATURE_18'
+    },
+    temperature23: {
+      'pseudo-mode': 'heat',
+      'data': 'TEMPERATURE_23'
+    },
+    'heat23.0': { // if we also look into 'heat' prefix, this should return true
+      'data': 'TEMPERATURE_23'
+    }
+  };
+
+  it('returns false for [16,18,23]', () => {
+    expect(hasGranularTemperatures(data, ['temperature'])).to.equal(false);
+  })
+
+  it('returns true for [16,18,23,23.0]', () => {
+    expect(hasGranularTemperatures(data, ['temperature', 'heat'])).to.equal(true);
+  })
+});
+
+describe('lookup', () => {
+  const data = {
+    on: 'ON',
+    off: 'OFF',
+    temperature16: {
+      'pseudo-mode': 'cool',
+      'data': 'TEMPERATURE_16'
+    },
+    temperature18: {
+      'pseudo-mode': 'cool',
+      'data': 'TEMPERATURE_18'
+    },
+    temperature23: {
+      'pseudo-mode': 'heat',
+      'data': 'TEMPERATURE_23'
+    },
+    'heat24.4': {
+      'data': 'TEMPERATURE_76F'
+    },
+    'heat25': {
+      'data': 'TEMPERATURE_77F'
+    },
+    'heat25.6': {
+      'data': 'TEMPERATURE_78F'
+    },
+    'heat26.1': {
+      'data': 'TEMPERATURE_79F'
+    },
+    'heat26.7': {
+      'data': 'TEMPERATURE_80F'
+    },
+  };
+
+  it('does exact integer lookups', () => {
+    expect(lookup(data, 'temperature', 16).data).to.equal('TEMPERATURE_16');
+    expect(lookup(data, 'temperature', 18).data).to.equal('TEMPERATURE_18');
+    expect(lookup(data, 'temperature', 23).data).to.equal('TEMPERATURE_23');
+  })
+
+  it('does fuzzy lookups', () => {
+    expect(lookup(data, 'heat', 24).data).to.equal('TEMPERATURE_76F');
+    expect(lookup(data, 'heat', 24.0).data).to.equal('TEMPERATURE_76F');
+    expect(lookup(data, 'heat', 24.1).data).to.equal('TEMPERATURE_76F');
+    expect(lookup(data, 'heat', 24.2).data).to.equal('TEMPERATURE_76F');
+    expect(lookup(data, 'heat', 24.3).data).to.equal('TEMPERATURE_76F');
+    expect(lookup(data, 'heat', 24.4).data).to.equal('TEMPERATURE_76F');
+
+    expect(lookup(data, 'heat', 24.8).data).to.equal('TEMPERATURE_77F');
+    expect(lookup(data, 'heat', 24.9).data).to.equal('TEMPERATURE_77F');
+    expect(lookup(data, 'heat', 25.0).data).to.equal('TEMPERATURE_77F');
+    expect(lookup(data, 'heat', 25.1).data).to.equal('TEMPERATURE_77F');
+    expect(lookup(data, 'heat', 25.2).data).to.equal('TEMPERATURE_77F');
+
+    expect(lookup(data, 'heat', 25.5).data).to.equal('TEMPERATURE_78F');
+    expect(lookup(data, 'heat', 25.6).data).to.equal('TEMPERATURE_78F');
+    expect(lookup(data, 'heat', 25.7).data).to.equal('TEMPERATURE_78F');
+
+    expect(lookup(data, 'heat', 26.0).data).to.equal('TEMPERATURE_79F');
+    expect(lookup(data, 'heat', 26.1).data).to.equal('TEMPERATURE_79F');
+    expect(lookup(data, 'heat', 26.2).data).to.equal('TEMPERATURE_79F');
+
+    expect(lookup(data, 'heat', 26.6).data).to.equal('TEMPERATURE_80F');
+    expect(lookup(data, 'heat', 26.7).data).to.equal('TEMPERATURE_80F');
+    expect(lookup(data, 'heat', 26.8).data).to.equal('TEMPERATURE_80F');
+  });
+
+  it('returns null if the target is too far away from known values', () => {
+    expect(lookup(data, 'heat', 9)).to.be.null;
+    expect(lookup(data, 'heat', 27.7)).to.be.null;
+  });
+
+  it('does not throw if prefix is not defined', () => {
+    expect(lookup(data, 'cool', 26)).to.be.null;
+  });
+});


### PR DESCRIPTION
# Context
My IR remote control PAR-SL100A-E controls the AC in 1 degree Fahrenheit increments (approximately 0.5 degrees Celsius).

This plugin currently sets a `minStep` of 1, so Home app will only send integer target temperatures in Celsius.  This conversion causes the Home app to "skip" many Fahrenheit set points.

I want to make available to HomeKit every Fahrenheit set point that my IR remote control supports.

# Proposed approach
* Allow temperature with decimal points in the `data` JSON map
* If decimal points are detected in the config, set `minStep` to 0.1 to allow HomeKit to send more accurate target temperatures
* Add fuzzy matching logic inside `getTemperatureHexData` when it is doing the lookup:
  * Find the closest match temperature with the correct prefix in the `data` JSON
  * If the temperature difference is less than 1 degree Celsius, return hex code for the closest defined temperature
  * Otherwise return null (have `getTemperatureHexData` handle this as usual)

# Sample config
```
                    "data": {
                        "off": "26006c...",
                        "temperature24.4": {
                            "data": "26006c...",
                            "pseudo-mode": "cool"
                        },
                        "temperature20.6": {
                            "data": "26006c...",
                            "pseudo-mode": "heat"
                        },
                        "heat17.2": {
                          // ...
```
Template JSON with F -> C mapping for 50F to 90F:
https://gist.github.com/jiehanzheng/955114994c409ff3cc8722ee99f62a6b