### PR TITLE
Fix fan switchState when resetting to defaults

### DIFF
--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -92,7 +92,7 @@ class FanAccessory extends SwitchAccessory {
 
   async setSwitchState(hexData, previousValue) {
     const { config, state, serviceManager } = this;
-    if (!this.state.switchState) {
+    if (!state.switchState) {
       this.lastFanSpeed = undefined;
     }
 
@@ -101,7 +101,7 @@ class FanAccessory extends SwitchAccessory {
     }
 
     // Reset the fan speed back to the default speed when turned off
-    if (this.state.switchState === false && config.alwaysResetToDefaults) {
+    if (!state.switchState && config.alwaysResetToDefaults) {
       this.setDefaults();
       serviceManager.setCharacteristic(Characteristic.RotationSpeed, state.fanSpeed);
     }


### PR DESCRIPTION
This pull request fixes the `switchState` value comparison which is always `0` or `1`.

As a result, https://github.com/kiwi-cam/homebridge-broadlink-rm/pull/286 now works correctly when turning a fan off.

@kiwi-cam do you know what the use case for `alwaysResetToDefaults` option in the [setDefaults](https://github.com/kiwi-cam/homebridge-broadlink-rm/blob/deb5f01/accessories/fan.js#L20-L26) method is? It's definitely needed in the [setSwitchState](https://github.com/kiwi-cam/homebridge-broadlink-rm/blob/deb5f01/accessories/fan.js#L103-L107) method when turning the fan off but causes problems when restarting Homebridge.

Perhaps there need to be two separate options, one for turning the fan off and one for restarting Homebridge. Also maybe a third option could fix https://github.com/kiwi-cam/homebridge-broadlink-rm/issues/303.