### PR TITLE
Ignore fanSpeed key when looking for fan speeds

### DIFF
--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -115,16 +115,13 @@ class FanAccessory extends SwitchAccessory {
     this.reset();
 
     // Create an array of speeds specified in the data config
-    const foundSpeeds = [];
-    const allHexKeys = Object.keys(data || {});
-
-    allHexKeys.forEach((key) => {
-      const parts = key.split('fanSpeed');
-
-      if (parts.length !== 2 || !parts[1]) {return;}
-
-      foundSpeeds.push(parts[1])
-    })
+    const foundSpeeds = Object.keys(data || {}).reduce((accu, key) => {
+      const match = key.match(/fanSpeed(\d+)/);
+      if (match && match[1]) {
+          accu.push(match[1]);
+      }
+      return accu;
+    }, []);
 
     if (config.speedCycle && config.speedSteps) {
       for (let i = 1; i <= config.speedSteps; i++) {

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -121,7 +121,7 @@ class FanAccessory extends SwitchAccessory {
     allHexKeys.forEach((key) => {
       const parts = key.split('fanSpeed');
 
-      if (parts.length !== 2) {return;}
+      if (parts.length !== 2 || !parts[1]) {return;}
 
       foundSpeeds.push(parts[1])
     })


### PR DESCRIPTION
This pull request fixes an empty string being added to the `foundSpeeds` array, the `fanSpeed` key is available in addition to `fanSpeedX` keys since https://github.com/kiwi-cam/homebridge-broadlink-rm/pull/286.

The result of the following is still desired:
`'fanSpeed20'.split('fanSpeed')[1]`

But not this:
`'fanSpeed'.split('fanSpeed')[1]`

The logic is then simplified in fb298a6.

The `fanSpeed` key is also missing from the [documentation](https://broadlink.kiwicam.nz/#fan).