### PR TITLE
Add minstep to aircon config

### DIFF
--- a/accessories/aircon.js
+++ b/accessories/aircon.js
@@ -62,6 +62,7 @@ class AirConAccessory extends BroadlinkRMAccessory {
     if (config.minimumAutoOnOffDuration === undefined) {config.minimumAutoOnOffDuration = config.autoMinimumDuration || 120;} // Backwards compatible with `autoMinimumDuration`
     config.minTemperature = config.minTemperature || -15;
     config.maxTemperature = config.maxTemperature || 50;
+    config.minStep = config.minStep || 1;
     if(config.mqttURL) {
       //MQTT updates when published so frequent refreshes aren't required ( 10 minute default as a fallback )
       config.temperatureUpdateFrequency = config.temperatureUpdateFrequency || 600;
@@ -866,7 +867,7 @@ class AirConAccessory extends BroadlinkRMAccessory {
       .setProps({
         minValue: config.minTemperature,
         maxValue: config.maxTemperature,
-        minStep: 1
+        minStep: config.minStep
       });
 
     this.serviceManager

--- a/test/airConditioner.test.js
+++ b/test/airConditioner.test.js
@@ -55,6 +55,7 @@ describe('airConAccessory', async () => {
     expect(airConAccessory.config.minimumAutoOnOffDuration).to.equal(120);
     expect(airConAccessory.config.minTemperature).to.equal(-15);
     expect(airConAccessory.config.maxTemperature).to.equal(50);
+    expect(airConAccessory.config.minStep).to.equal(1);
     expect(airConAccessory.config.units).to.equal('c');
     expect(airConAccessory.config.temperatureUpdateFrequency).to.equal(10);
     expect(airConAccessory.config.temperatureAdjustment).to.equal(0);
@@ -74,6 +75,7 @@ describe('airConAccessory', async () => {
       minimumAutoOnOffDuration: 60,
       minTemperature: 2,
       maxTemperature: 36,
+      minStep: 0.5,
       units: 'f',
       temperatureUpdateFrequency: 20,
       temperatureAdjustment: 1,
@@ -89,6 +91,7 @@ describe('airConAccessory', async () => {
     expect(airConAccessory.config.minimumAutoOnOffDuration).to.equal(60);
     expect(airConAccessory.config.minTemperature).to.equal(2);
     expect(airConAccessory.config.maxTemperature).to.equal(36);
+    expect(airConAccessory.config.minStep).to.equal(0.5);
     expect(airConAccessory.config.units).to.equal('f');
     expect(airConAccessory.config.temperatureUpdateFrequency).to.equal(20);
     expect(airConAccessory.config.temperatureAdjustment).to.equal(1);


### PR DESCRIPTION
Add minstep to aircon config. Some air conditioners support 0.5 degree temperature adjustment. Adding this feature will help.