### PR TITLE
Fix fan characteristic warning

### DIFF
--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -1,12 +1,23 @@
 const ServiceManagerTypes = require('../helpers/serviceManagerTypes');
-const SwitchAccessory = require('./switch');
+const BroadlinkRMAccessory = require('./accessory');
 const catchDelayCancelError = require('../helpers/catchDelayCancelError');
 const delayForDuration = require('../helpers/delayForDuration');
+const ping = require('../helpers/ping');
 
-class FanAccessory extends SwitchAccessory {
+class FanAccessory extends BroadlinkRMAccessory {
+  constructor(log, config = {}, serviceManagerType) {
+    super(log, config, serviceManagerType);
+
+    if (!config.isUnitTest) {this.checkPing(ping);}
+  }
+
   setDefaults() {
-    super.setDefaults();
     let { config, state } = this;
+    config.pingFrequency = config.pingFrequency || 1;
+    config.pingGrace = config.pingGrace || 10;
+
+    config.offDuration = config.offDuration || 60;
+    config.onDuration = config.onDuration || 60;
 
     // Defaults
     config.showSwingMode = config.hideSwingMode === true || config.showSwingMode === false ? false : true;
@@ -47,6 +58,11 @@ class FanAccessory extends SwitchAccessory {
       this.autoOnTimeoutPromise = null;
     }
 
+    if (this.pingGraceTimeout) {
+      this.pingGraceTimeout.cancel();
+      this.pingGraceTimeout = null;
+    }
+
     if (this.serviceManager.getCharacteristic(Characteristic.Active) === undefined) {
       this.serviceManager.setCharacteristic(Characteristic.Active, false);
     }
@@ -54,8 +70,65 @@ class FanAccessory extends SwitchAccessory {
 
   checkAutoOnOff() {
     this.reset();
+    this.checkPingGrace();
     this.checkAutoOn();
     this.checkAutoOff();
+  }
+
+  checkPing(ping) {
+    const { config } = this;
+    let { pingIPAddress, pingFrequency, pingUseArp } = config;
+
+    if (!pingIPAddress) {return;}
+
+    // Setup Ping/Arp-based State
+    if(!pingUseArp) {ping(pingIPAddress, pingFrequency, this.pingCallback.bind(this))}
+    else {arp(pingIPAddress, pingFrequency, this.pingCallback.bind(this))}
+  }
+
+  pingCallback(active) {
+    const { config, state, serviceManager } = this;
+
+    if (this.stateChangeInProgress){
+      return;
+    }
+
+    if (config.pingIPAddressStateOnly) {
+      state.switchState = active ? true : false;
+      serviceManager.refreshCharacteristicUI(Characteristic.Active);
+
+      return;
+    }
+
+    const value = active ? true : false;
+    serviceManager.setCharacteristic(Characteristic.Active, value);
+  }
+
+  async setSwitchState(hexData) {
+    const { data, host, log, name, logLevel } = this;
+
+    this.stateChangeInProgress = true;
+    this.reset();
+
+    if (hexData) {await this.performSend(hexData);}
+
+    this.checkAutoOnOff();
+  }
+
+  async checkPingGrace () {
+    await catchDelayCancelError(async () => {
+      const { config, log, name, state, serviceManager } = this;
+
+      let { pingGrace } = config;
+
+      if (pingGrace) {
+
+        this.pingGraceTimeoutPromise = delayForDuration(pingGrace);
+        await this.pingGraceTimeoutPromise;
+
+        this.stateChangeInProgress = false;
+      }
+    });
   }
 
   async checkAutoOff() {
@@ -106,7 +179,9 @@ class FanAccessory extends SwitchAccessory {
       serviceManager.setCharacteristic(Characteristic.RotationSpeed, state.fanSpeed);
     }
 
-    super.setSwitchState(hexData, previousValue);
+    this.reset();
+
+    if (hexData) {await this.performSend(hexData);}
   }
 
   async setFanSpeed(hexData) {


### PR DESCRIPTION
This pull request fixes the following warning:
`
This plugin generated a warning from the characteristic 'On': Characteristic not in required or optional characteristic section for service Fanv2. Adding anyway.. See https://homebridge.io/w/JtMGR for more info.
`

The Fanv2 service [does not support](https://github.com/homebridge/HAP-NodeJS/blob/93a9743c6ae5b6ba3cb4949ef418341234812226/src/lib/definitions/ServiceDefinitions.ts#L599) this characteristic, the solution is to subclass from `BroadlinkRMAccessory` like the `TVAccessory` (https://github.com/kiwi-cam/homebridge-broadlink-rm/blob/d78bc1902e11bf64438c63ca7ba8a43fe094e921/accessories/tv.js) does.
 
This fixes the warning in https://github.com/kiwi-cam/homebridge-broadlink-rm/issues/624#issuecomment-1636065954.