### PR TITLE
Add support for check-alive using Meross plug power consumption reading

### DIFF
--- a/helpers/meross.js
+++ b/helpers/meross.js
@@ -1,0 +1,41 @@
+const { createHash, randomBytes } = require('crypto');
+
+// adapted from https://github.com/bwp91/homebridge-meross
+const merossCheckAlive = (accessoryIp, accessoryUuid, userKey, wattageThreshold, interval, callback) => {
+  setInterval(() => {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const messageId = randomBytes(16).toString('hex');
+    const sign = createHash('md5').update(messageId + userKey + timestamp).digest('hex');
+
+    fetch(`http://${accessoryIp}/config`, {
+      method: 'POST',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        header: {
+          from: 'anything',
+          messageId,
+          method: 'GET',
+          namespace: 'Appliance.Control.Electricity',
+          payloadVersion: 1,
+          sign,
+          timestamp,
+          triggerSrc: 'iOSLocal',
+          uuid: accessoryUuid,
+        },
+        payload: {},
+      }),
+      signal: AbortSignal.timeout(1000),
+    }).then((response) => {
+      return response.json();
+    }).then((data) => {
+      const currentWattage = data.payload.electricity.power / 1000;
+      callback(currentWattage >= wattageThreshold);
+    }).catch(() => {
+      callback(false);
+    });
+  }, interval * 1000);
+}
+
+module.exports = merossCheckAlive;


### PR DESCRIPTION
Fixes https://github.com/kiwi-cam/homebridge-broadlink-rm/issues/700

---

Adding support for "ping" / check-alive capability using Meross smart plug's power consumption measurement.
Tested plug models: MSS310 & MSS315. 

Accessory UUID & user key can be obtained via the Meross plugin https://github.com/bwp91/homebridge-meross

Configuration:
```json
"pingUseMeross": true,
"pingExtraConfig": {
  "merossAccessoryUuid": "PASTE_ACCESSORY_UUID_HERE",
  "merossUserKey": "PASTE_USER_KEY_HERE",
  "wattageThreshold": 10
}
```