### PR TITLE
Scan RF code of specified frequency

### DIFF
--- a/accessories/learnCode.js
+++ b/accessories/learnCode.js
@@ -21,15 +21,16 @@ class LearnIRAccessory extends BroadlinkRMAccessory {
 
   toggleLearning(props, on, callback) {
     const { config, serviceManager } = this;
-    const { disableAutomaticOff, scanRF, scanFrequency } = config;
+    const { disableAutomaticOff, scanRF, scanFrequency, frequency } = config;
 
     const turnOffCallback = () => {
       serviceManager.setCharacteristic(Characteristic.On, false);
     }
 
     if (scanRF || scanFrequency) {
+      const scan = frequency ?? undefined;
       if (on) {
-        learnRFData.start(this.host, callback, turnOffCallback, this.log, disableAutomaticOff, this.logLevel);
+        learnRFData.start(this.host, scan, callback, turnOffCallback, this.log, disableAutomaticOff, this.logLevel);
       } else {
         learnRFData.stop(this.log, this.logLevel);
 

--- a/helpers/learnRFData.js
+++ b/helpers/learnRFData.js
@@ -28,7 +28,7 @@ const stop = (log, device, logLevel) => {
   if(this.initalDebug !== undefined && currentDevice) {currentDevice.debug = this.initalDebug;}
 }
 
-const start = (host, callback, turnOffCallback, log, disableTimeout, logLevel) => {
+const start = (host, frequency, callback, turnOffCallback, log, disableTimeout, logLevel) => {
   stop()
 
   // Get the Broadlink device
@@ -91,7 +91,7 @@ const start = (host, callback, turnOffCallback, log, disableTimeout, logLevel) =
     if (!closeClient) {return;}
 
     if (getDataTimeout2) {clearTimeout(getDataTimeout2);}
-    getDataTimeout = null;
+    getDataTimeout2 = null;
 
     log(`\x1b[35m[INFO]\x1b[0m Scan RF (found frequency - 2 of 2)`)
     log(`\x1b[35m[ACTION]\x1b[0m Press the RF button multiple times with a pause between them to get code.`);
@@ -119,15 +119,21 @@ const start = (host, callback, turnOffCallback, log, disableTimeout, logLevel) =
   device.on('rawRFData2', onRawData2);
   device.on('rawData', onRawData3);
 
-  device.enterRFSweep();
-  log(`\x1b[35m[INFO]\x1b[0m Scan RF (scanning)`);
-  log(`\x1b[35m[ACTION]\x1b[0m Hold down the button that sends the RF frequency.`);
-
   if (callback) {callback();}
 
-  getDataTimeout = setTimeout(() => {
-    getData(device);
-  }, 1000);
+  if (!frequency) {
+    device.enterRFSweep();
+    log(`\x1b[35m[INFO]\x1b[0m Scan RF (scanning)`);
+    log(`\x1b[35m[ACTION]\x1b[0m Hold down the button that sends the RF frequency.`);
+    
+    getDataTimeout = setTimeout(() => {
+      getData(device);
+    }, 1000);
+  } else {
+    getDataTimeout2 = setTimeout(() => {
+      getData2(device, frequency);
+    }, 1000);
+  }
 
   if (disableTimeout) {return;}
 
@@ -155,14 +161,14 @@ const getData = (device) => {
   }, 1000);
 }
 
-const getData2 = (device) => {
+const getData2 = (device, frequency = undefined) => {
   if (getDataTimeout2) {clearTimeout(getDataTimeout2);}
   if (!closeClient) {return;}
 
-  device.checkRFData2();
+  device.checkRFData2(frequency);
 
   getDataTimeout2 = setTimeout(() => {
-    getData2(device);
+    getData2(device, frequency);
   }, 1000);
 }
 


### PR DESCRIPTION
Note that this PR requires kiwi-cam/broadlinkjs-rm#23

This PR adds a function to scan RF code of specified frequency for learn-code accessory. Use new config keyword 'frequency' to specify the frequency as follows.


```
 {
                    "name": "...",
                    "type": "learn-code",
		    "frequency": 339.9,
		    "scanRF": true
}
```
