### PR TITLE
Track devices by MAC and re-discover on a schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+ - Broadlink devices are now tracked by MAC address and followed across DHCP address changes, instead of being pinned to the address they were first discovered at.
+### Added
+ - `rediscoveryInterval` platform option (minutes, default 60, `0` disables): re-runs broadcast discovery on a schedule and logs a health line per device, flagging any device stuck on a link-local `169.254.x.x` address.
+
 ## [4.4.21 - 2026-05-10
 ### Fixed
  - Homebridge 2.0 compatibility: access HAP categories via `hap.Categories` instead of `hap.Accessory.Categories`. (#777 thanks @Gernot)

--- a/config-sample.json
+++ b/config-sample.json
@@ -15,6 +15,7 @@
 		"hideScanFrequencyButton": false,
 		"hideLearnButton": false,
 		"hideWelcomeMessage": false,
+		"rediscoveryInterval": 60,
 		"accessories": [{
 				"name": "Auto-off Switch",
 				"type": "switch",

--- a/helpers/getDevice.js
+++ b/helpers/getDevice.js
@@ -8,8 +8,17 @@ const pingFrequency = 5000;
 const keepAliveFrequency = 90000;
 const pingTimeout = 5;
 
+// Default interval (minutes) for the scheduled re-discovery sweep.
+// Broadcast discovery is the only reliable MAC -> IP mapping we have, so we
+// re-run it periodically instead of only once at startup. That way a device
+// that took a new DHCP lease, or that was offline when Homebridge booted, is
+// picked up without a restart.
+const defaultRediscoveryInterval = 60;
+
 const startKeepAlive = (device, log) => {
   if(!device.host.port) {return;}
+  if(device.keepAliveStarted) {return;} // deviceReady fires again on re-auth
+  device.keepAliveStarted = true;
   setInterval(() => {
     if(broadlink.debug) {log('\x1b[33m[DEBUG]\x1b[0m Sending keepalive to', device.host.address,':',device.host.port)}
     const socket = dgram.createSocket({ type:'udp4', reuseAddr:true }); 
@@ -23,6 +32,8 @@ const startKeepAlive = (device, log) => {
 }
 
 const startPing = (device, log) => {
+  if(device.pingStarted) {return;} // deviceReady fires again on re-auth
+  device.pingStarted = true;
   device.state = 'unknown';
   device.retryCount = 1;
 
@@ -39,6 +50,11 @@ const startPing = (device, log) => {
 
           device.state = 'inactive';
           device.retryCount = 0;
+
+          // A device that dropped off its address is exactly the case a
+          // broadcast sweep can fix, so kick one off immediately rather than
+          // waiting for the next scheduled sweep.
+          runDiscoveryBurst(log, 15);
         } else if (!active && device.state === 'active') {
           if(broadlink.debug) {log(`Broadlink RM device at ${device.host.address} (${device.host.macAddress || ''}) is no longer reachable. (attempt ${device.retryCount})`);}
 
@@ -63,7 +79,74 @@ const discoveredDevices = {};
 const manualDevices = {};
 let discoverDevicesInterval;
 
-const discoverDevices = (automatic = true, log, logLevel, deviceDiscoveryTimeout = 60) => {
+// Helpers below implement MAC-first addressing and scheduled re-discovery.
+const macAddressPattern = /^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/;
+
+const normaliseMac = (mac) => {
+  if (!mac) {return null;}
+  if (Buffer.isBuffer(mac)) {
+    return (mac.toString('hex').match(/[\s\S]{1,2}/g) || []).join(':').toLowerCase();
+  }
+  const value = mac.toString();
+  if (value.includes(':')) {return value.toLowerCase();}
+  return (value.match(/[\s\S]{1,2}/g) || []).join(':').toLowerCase();
+}
+
+const isLinkLocal = (address) => typeof address === 'string' && address.startsWith('169.254.');
+
+let discoveryBurstInterval = null;
+
+// Fire a short burst of broadcast discovery packets. Broadlink devices only
+// answer a broadcast, so a burst is how we learn the current IP of every device
+// on the LAN, keyed by MAC.
+const runDiscoveryBurst = (log, durationSeconds = 30) => {
+  if (discoveryBurstInterval) {return;} // a burst is already in flight
+
+  discoveryBurstInterval = setInterval(() => {
+    broadlink.discover();
+  }, 2000);
+
+  broadlink.discover();
+
+  const stop = () => {
+    clearInterval(discoveryBurstInterval);
+    discoveryBurstInterval = null;
+  }
+
+  delayForDuration(durationSeconds).then(stop).catch(stop);
+}
+
+// Log one line per known device so an unhealthy device is visible in the log
+// without having to reproduce a failed send.
+const reportDeviceHealth = (log) => {
+  const seen = {};
+
+  Object.keys(discoveredDevices).forEach((key) => {
+    const device = discoveredDevices[key];
+    if (!device || typeof device !== 'object') {return;}
+
+    const mac = device.host.macAddress || normaliseMac(device.mac) || key;
+    if (seen[mac]) {return;}
+    seen[mac] = true;
+
+    const address = device.host.address;
+    const reachable = device.state === undefined ? 'unknown' : device.state;
+    const authenticated = device.authenticated === undefined ? 'unknown' : (device.authenticated ? 'yes' : 'no');
+
+    if (isLinkLocal(address)) {
+      log(`\x1b[31m[ERROR]\x1b[0m Broadlink device ${mac} is on a link-local address (${address}). It failed to get a DHCP lease, so it can only be reached by broadcast and will not respond to commands. Reserve an IP for this MAC on the router and power-cycle the device.`);
+      return;
+    }
+
+    log(`\x1b[35m[INFO]\x1b[0m Broadlink health: ${mac} at ${address} - reachable: ${reachable}, authenticated: ${authenticated}`);
+  });
+
+  Object.keys(manualDevices).forEach((key) => {
+    log(`\x1b[33m[WARN]\x1b[0m Broadlink device ${key} has never been discovered on this network. Check that it is powered on and joined to the same VLAN/subnet as Homebridge.`);
+  });
+}
+
+const discoverDevices = (automatic = true, log, logLevel, deviceDiscoveryTimeout = 60, rediscoveryInterval = defaultRediscoveryInterval) => {
   broadlink.log = log;
   broadlink.debug = logLevel <=1;
   //broadlink.logLevel = logLevel;
@@ -96,30 +179,90 @@ const discoverDevices = (automatic = true, log, logLevel, deviceDiscoveryTimeout
     startPing(device, log);
     startKeepAlive(device, log);
   })
+
+  // A device that changed IP re-authenticates against its new address.
+  // Re-index it so lookups by the old IP stop resolving to it.
+  broadlink.on('deviceMoved', (device) => {
+    const macAddress = normaliseMac(device.mac);
+    device.host.macAddress = macAddress;
+
+    // Only re-index a device that was already usable. One that has never
+    // authenticated - a device sitting on a link-local address, for instance -
+    // is registered by the deviceReady handler once its handshake succeeds.
+    // Registering it here would hand accessories a device they cannot reach,
+    // turning a fast "no device found" into a read that never responds.
+    if (discoveredDevices[macAddress]) {addDevice(device);}
+  })
+
+  // Scheduled sweep. Runs in both automatic and manual-hosts mode - in manual
+  // mode the configured addresses are only a starting hint, and the sweep is
+  // what keeps them correct when DHCP hands out a different IP.
+  if (rediscoveryInterval > 0) {
+    // Always keep a broadcast sweep available, even when "hosts" is configured
+    // and the initial automatic discovery was skipped.
+    if (!automatic) {runDiscoveryBurst(log, deviceDiscoveryTimeout);}
+
+    setInterval(() => {
+      log(`\x1b[35m[INFO]\x1b[0m Running scheduled Broadlink device discovery (every ${rediscoveryInterval} minutes).`);
+      runDiscoveryBurst(log, 30);
+
+      delayForDuration(35).then(() => reportDeviceHealth(log)).catch(() => {});
+    }, rediscoveryInterval * 60 * 1000);
+  }
 }
 
 const addDevice = (device) => {
-  if (!device.isUnitTestDevice && (discoveredDevices[device.host.address] || discoveredDevices[device.host.macAddress])) {return;}
+  // Index by MAC first and drop any stale IP key, so a device that moved to a
+  // new address is reachable under its new IP and not its old one.
+  const macAddress = device.host.macAddress || normaliseMac(device.mac);
 
-  device.mutex = new Mutex();
+  if (device.isUnitTestDevice) {
+    device.mutex = device.mutex || new Mutex();
+    discoveredDevices[device.host.address] = device;
+    if (macAddress) {discoveredDevices[macAddress] = device;}
+    return;
+  }
+
+  if (!device.mutex) {device.mutex = new Mutex();}
+
+  // Remove any address key that used to point at this device but no longer
+  // matches its current address.
+  Object.keys(discoveredDevices).forEach((key) => {
+    if (discoveredDevices[key] === device && key !== macAddress && key !== device.host.address) {
+      delete discoveredDevices[key];
+    }
+  });
 
   discoveredDevices[device.host.address] = device;
-  discoveredDevices[device.host.macAddress] = device;
+  if (macAddress) {
+    discoveredDevices[macAddress] = device;
+    // A real device turned up for this MAC, so the placeholder is obsolete.
+    delete manualDevices[macAddress];
+  }
 }
 
 const getDevice = ({ host, log, learnOnly }) => {
   let device;
 
   if (host) {
-    device = discoveredDevices[host];
+    // Accessories reference devices by MAC, so normalise the lookup key before
+    // going to the index.
+    const key = macAddressPattern.test(host) ? host.toLowerCase() : host;
+    device = discoveredDevices[key];
 
     // Create manual device
-    if (!device && !manualDevices[host]) {
-      const device = { host: { address: host } };
-      manualDevices[host] = device;
+    if (!device && !manualDevices[key]) {
+      // A MAC is not routable - there is nothing to ping or keep alive, so just
+      // record that we are still waiting for this device to be discovered.
+      if (macAddressPattern.test(key)) {
+        manualDevices[key] = { host: { macAddress: key } };
+      } else {
+        const device = { host: { address: key } };
+        manualDevices[key] = device;
 
-      startPing(device, log);
-      startKeepAlive(device, log);
+        startPing(device, log);
+        startKeepAlive(device, log);
+      }
     }
   } else { // use the first one of no host is provided
     const hosts = Object.keys(discoveredDevices);

--- a/platform.js
+++ b/platform.js
@@ -108,16 +108,35 @@ const BroadlinkRMPlatform = class extends HomebridgePlatform {
     const { config, log, logLevel } = this;
     const { hosts } = config;
 
+    // How often (minutes) broadcast discovery is re-run to refresh the
+    // MAC -> IP mapping. 0 disables the scheduled sweep.
+    const rediscoveryInterval = config.rediscoveryInterval === undefined ? 60 : config.rediscoveryInterval;
+
+    const logRediscovery = () => {
+      if (logLevel > 2) {return;}
+
+      if (rediscoveryInterval > 0) {
+        log(`\x1b[35m[INFO]\x1b[0m Devices are tracked by MAC address and re-discovered every ${rediscoveryInterval} minutes.`)
+      } else {
+        log(`\x1b[33m[WARN]\x1b[0m Scheduled re-discovery is disabled ("rediscoveryInterval": 0). A device that is given a different IP address will stay unreachable until Homebridge is restarted.`)
+      }
+    }
+
     if (!hosts) {
       if (logLevel <=2) {log(`\x1b[35m[INFO]\x1b[0m Automatically discovering Broadlink RM devices.`)}
-      discoverDevices(true, log, logLevel, config.deviceDiscoveryTimeout);
+      logRediscovery();
+      discoverDevices(true, log, logLevel, config.deviceDiscoveryTimeout, rediscoveryInterval);
 
       return;
     }
 
-    discoverDevices(false, log, logLevel);
+    discoverDevices(false, log, logLevel, config.deviceDiscoveryTimeout, rediscoveryInterval);
 
-    if (logLevel <=2) {log(`\x1b[35m[INFO]\x1b[0m Automatic Broadlink RM device discovery has been disabled as the "hosts" option has been set.`)}
+    // The configured addresses are a starting point only. Broadcast discovery
+    // still runs, so a device that is given a new DHCP lease is followed to its
+    // new address instead of going silently unreachable.
+    if (logLevel <=2) {log(`\x1b[35m[INFO]\x1b[0m Using the "hosts" option for the initial device addresses.`)}
+    logRediscovery();
 
     assert.isArray(hosts, `\x1b[31m[CONFIG ERROR] \x1b[33mhosts\x1b[0m should be an array of objects.`)
 


### PR DESCRIPTION
### The problem

Devices are resolved to an IP address exactly once, at startup.
`discoverDevices()` stops broadcasting after `deviceDiscoveryTimeout`, and when
`hosts` is configured discovery never runs at all. From then on
`discoveredDevices` holds whatever address the device had at that moment, so:

- a device given a different DHCP lease keeps being sent to its old address and
  fails with `sendData (no device found at <mac>)` until Homebridge is restarted;
- a device that is powered off, or still booting, during the startup window is
  never picked up, even after it comes back.

There is a third failure that is much harder to diagnose. A device that fails
DHCP falls back to a link-local `169.254.x.x` address. It still answers the
discovery broadcast, so it looks present, but it cannot be reached by unicast and
authentication never completes. It does not show up in a ping sweep or in the ARP
table either, so from the log it is indistinguishable from a device that is
simply switched off.

### The change

- `addDevice()` / `getDevice()` index by MAC first, normalise the MAC case, and
  drop a stale address key when a device moves, so accessories configured with
  `"host": "<mac>"` always resolve to the device's current address.
- `getDevice()` no longer starts an ICMP ping and a keepalive against a MAC when
  the device has not been discovered yet. A MAC is not routable, so the old
  placeholder pinged a hostname that could never answer.
- New `rediscoveryInterval` platform option (minutes, default 60, `0` disables)
  re-runs broadcast discovery on a schedule, in both automatic and manual-hosts
  mode. With `hosts` set, the configured addresses become a starting hint rather
  than a pin.
- A device that fails three consecutive pings triggers an immediate sweep rather
  than waiting for the next scheduled one.
- Each scheduled sweep logs one health line per device (address, reachability,
  authentication) and raises an error for any device on a link-local address,
  saying what it means and what to do about it.
- `startPing()` / `startKeepAlive()` are guarded so re-authentication does not
  stack a second interval per device.

### Configuration

Nothing is required. Existing configurations keep working, and pick up the hourly
sweep by default.

```json
{
  "platform": "BroadlinkRM",
  "rediscoveryInterval": 60
}
```

### Log output

```
[INFO] Using the "hosts" option for the initial device addresses.
[INFO] Devices are tracked by MAC address and re-discovered every 60 minutes.
[INFO] Broadlink device ec0bae850041 moved from 192.168.0.126 to 192.168.0.121. Re-authenticating.
[INFO] Running scheduled Broadlink device discovery (every 60 minutes).
[INFO] Broadlink health: ec:0b:ae:8c:3f:f2 at 192.168.0.124 - reachable: active, authenticated: yes
[ERROR] Broadlink device ec:0b:ae:84:fd:90 is on a link-local address (169.254.145.253). It failed
        to get a DHCP lease, so it can only be reached by broadcast and will not respond to
        commands. Reserve an IP for this MAC on the router and power-cycle the device.
```

### Dependency

Following a device to its new address also needs
`kiwi-cam/broadlinkjs-rm` to stop ignoring discovery replies from a known MAC
(kiwi-cam/broadlinkjs-rm#28). Without it, the
scheduled sweep, the MAC-first lookups and the health logging still work, but an
address change is only picked up on restart.

### Testing

- `npm run lint` clean (the one pre-existing `curly` warning in `platform.js` is
  unchanged).
- Four RM4 Pro devices, seeded with deliberately wrong addresses in `hosts`: all
  four were followed to their real addresses, re-authenticated, and answered a
  command afterwards. Lookups by uppercase MAC resolve correctly.
- Two of those devices were genuinely stuck on `169.254.x.x` during testing, which
  is what prompted the health logging; the error fired as intended and the devices
  were correctly reported as not authenticated rather than being handed to
  accessories.
- The unit tests were not used as a gate: `mocha --recursive test` reports 132
  failing / 0 passing on an unmodified `beta` checkout, and CI runs `npm run lint`
  only.