### PR TITLE
Add a configuration UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+ - Configuration UI. The plugin now ships a `config.schema.json` and a custom Homebridge UI, so it can be set up from a form instead of by hand-editing config.json. It scans the network for Broadlink devices, reports whether each one is reachable, locked to the cloud or missing a DHCP lease, and offers an accessory editor that shows only the options that apply to the chosen accessory type.
+ - Learning codes from the configuration UI. Every accessory type has a labelled slot for each hex code it can hold, with a Learn button (and Learn RF on RM Pro / RM4 Pro) that writes the captured code straight into the accessory, a Test button that sends it back out, and a guided pass that walks through every missing code in one go.
+
 ## [4.4.21 - 2026-05-10
 ### Fixed
  - Homebridge 2.0 compatibility: access HAP categories via `hap.Categories` instead of `hap.Accessory.Categories`. (#777 thanks @Gernot)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ This plugin can be added via the Web interface, or if you perfer the terminal:
    `npm install -g homebridge-broadlink-rm-pro`
 For more information, refer to the [documentation](https://broadlink.kiwicam.nz/#installation).
 
+## Configuration
+
+The plugin ships a configuration UI. In the Homebridge web interface, open **Plugins**, find
+**Homebridge Broadlink RM Pro** and choose **Settings**. From there you can scan the network
+for your RM devices, see whether each one is reachable, and add accessories from a form that
+shows only the options relevant to the accessory type you picked.
+
+Editing `config.json` by hand still works, and every option is listed in the documentation
+below.
+
 ## Documentation
 
 **Documentation can be found [here](https://broadlink.kiwicam.nz).** If you have any trouble after reading through the information please raise an issue and we'll help out as best we can.

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,0 +1,145 @@
+{
+  "pluginAlias": "BroadlinkRM",
+  "pluginType": "platform",
+  "singular": true,
+  "customUi": true,
+  "headerDisplay": "Control Broadlink RM devices from HomeKit. Use **Devices** to find the RM units on your network, then add an accessory for each thing you want to control. Full documentation: [broadlink.kiwicam.nz](https://broadlink.kiwicam.nz).",
+  "footerDisplay": "If a device is not found, check that it is not locked to the Broadlink cloud: open the Broadlink app, tap the device, tap the **...** menu and switch **Lock device** off.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "title": "Name",
+        "type": "string",
+        "default": "Broadlink RM",
+        "required": true,
+        "description": "A friendly name for the platform, used by Homebridge in its logs."
+      },
+      "logLevel": {
+        "title": "Log level",
+        "type": "string",
+        "default": "info",
+        "oneOf": [
+          {
+            "title": "None - log nothing",
+            "enum": [
+              "none"
+            ]
+          },
+          {
+            "title": "Critical - unrecoverable failures only",
+            "enum": [
+              "critical"
+            ]
+          },
+          {
+            "title": "Error - failures that stop the current action",
+            "enum": [
+              "error"
+            ]
+          },
+          {
+            "title": "Warning - unexpected but recoverable events",
+            "enum": [
+              "warning"
+            ]
+          },
+          {
+            "title": "Info (default) - status changes and general flow",
+            "enum": [
+              "info"
+            ]
+          },
+          {
+            "title": "Debug - detail useful when investigating a problem",
+            "enum": [
+              "debug"
+            ]
+          },
+          {
+            "title": "Trace - everything",
+            "enum": [
+              "trace"
+            ]
+          }
+        ],
+        "description": "How much detail the platform and its devices write to the Homebridge log."
+      },
+      "deviceDiscoveryTimeout": {
+        "title": "Discovery timeout (seconds)",
+        "type": "integer",
+        "default": 60,
+        "minimum": 5,
+        "maximum": 600,
+        "description": "How long the network is scanned for devices at start-up when automatic discovery is used."
+      },
+      "hideLearnButton": {
+        "title": "Hide the Learn accessory",
+        "type": "boolean",
+        "default": false,
+        "description": "Stops the Learn switch, used to learn IR codes, from being added to HomeKit."
+      },
+      "hideScanFrequencyButton": {
+        "title": "Hide the Scan Frequency accessory",
+        "type": "boolean",
+        "default": false,
+        "description": "Stops the Scan Frequency switch, used to learn RF codes, from being added to HomeKit."
+      },
+      "hideWelcomeMessage": {
+        "title": "Hide the welcome message",
+        "type": "boolean",
+        "default": false,
+        "description": "Stops the welcome banner being written to the log at start-up."
+      },
+      "isUnitTest": {
+        "title": "Unit test mode",
+        "type": "boolean",
+        "default": false,
+        "description": "Disables ongoing pings and temperature polling. Intended for testing only."
+      },
+      "hosts": {
+        "title": "Devices",
+        "type": "array",
+        "description": "Set these to skip automatic discovery and use fixed addresses instead. Leave empty to discover devices automatically.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "address": {
+              "title": "IP address",
+              "type": "string",
+              "required": true,
+              "format": "ipv4",
+              "placeholder": "192.168.1.32"
+            },
+            "mac": {
+              "title": "MAC address",
+              "type": "string",
+              "required": true,
+              "pattern": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
+              "placeholder": "34:ea:34:e7:d7:28"
+            },
+            "isRFSupported": {
+              "title": "Supports RF",
+              "type": "boolean",
+              "default": false,
+              "description": "Set for RM Pro and RM4 Pro units, which can send RF as well as IR."
+            },
+            "isRM4": {
+              "title": "Is an RM4 device",
+              "type": "boolean",
+              "default": false,
+              "description": "Set for RM4 Mini and RM4 Pro units, which need different packet headers."
+            }
+          }
+        }
+      },
+      "accessories": {
+        "title": "Accessories",
+        "type": "array",
+        "items": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -1,0 +1,934 @@
+<style>
+  .brm-wrap { font-size: 0.9rem; }
+  .brm-wrap .nav-tabs { margin-bottom: 1rem; }
+  .brm-hint { font-size: 0.8rem; opacity: 0.7; margin: 0.15rem 0 0; }
+  .brm-section { border: 1px solid rgba(128,128,128,0.25); border-radius: 0.5rem; padding: 0.9rem 1rem; margin-bottom: 1rem; }
+  .brm-section > h6 { margin: 0 0 0.75rem; font-weight: 600; letter-spacing: 0.02em; text-transform: uppercase; font-size: 0.72rem; opacity: 0.65; }
+  .brm-row { display: flex; gap: 1rem; align-items: flex-start; }
+  .brm-list { flex: 0 0 15rem; max-height: 30rem; overflow-y: auto; border: 1px solid rgba(128,128,128,0.25); border-radius: 0.5rem; }
+  .brm-list button { display: block; width: 100%; text-align: left; border: 0; background: transparent; padding: 0.45rem 0.7rem; color: inherit; border-bottom: 1px solid rgba(128,128,128,0.15); }
+  .brm-list button:hover { background: rgba(128,128,128,0.12); }
+  .brm-list button.active { background: rgba(13,110,253,0.15); font-weight: 600; }
+  .brm-list .brm-list-type { display: block; font-size: 0.72rem; opacity: 0.6; font-weight: 400; }
+  .brm-editor { flex: 1 1 auto; min-width: 0; }
+  .brm-device { border: 1px solid rgba(128,128,128,0.25); border-radius: 0.5rem; padding: 0.7rem 0.9rem; margin-bottom: 0.6rem; }
+  .brm-device-head { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+  .brm-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.82rem; }
+  .brm-empty { opacity: 0.6; text-align: center; padding: 1.6rem 0.5rem; }
+  .brm-data { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.78rem; min-height: 11rem; }
+  .brm-group { margin-bottom: 0.9rem; }
+  .brm-group > span { display: block; font-size: 0.72rem; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; opacity: 0.6; margin-bottom: 0.3rem; }
+  .brm-code { display: flex; align-items: center; gap: 0.5rem; padding: 0.35rem 0.5rem; border: 1px solid rgba(128,128,128,0.2); border-radius: 0.4rem; margin-bottom: 0.3rem; flex-wrap: wrap; }
+  .brm-code.is-target { border-color: #0d6efd; box-shadow: 0 0 0 2px rgba(13,110,253,0.18); }
+  .brm-code-label { font-weight: 600; flex: 0 0 11rem; }
+  .brm-code-hex { flex: 1 1 6rem; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; opacity: 0.65; }
+  .brm-code .btn { padding: 0.12rem 0.5rem; font-size: 0.74rem; }
+  .brm-learn { border: 1px solid #0d6efd; border-radius: 0.5rem; padding: 0.75rem 0.9rem; margin-bottom: 0.9rem; background: rgba(13,110,253,0.06); }
+  .brm-learn-state { font-weight: 600; margin: 0 0 0.2rem; }
+  .brm-add { display: flex; gap: 0.4rem; align-items: flex-end; flex-wrap: wrap; margin-top: 0.6rem; }
+  .brm-add > * { flex: 0 0 auto; }
+  .brm-add select, .brm-add input { width: auto; min-width: 7rem; }
+  details.brm-raw { margin-top: 0.9rem; }
+  details.brm-raw > summary { cursor: pointer; font-size: 0.8rem; opacity: 0.7; }
+  @media (max-width: 560px) { .brm-code-label { flex-basis: 100%; } }
+  @media (max-width: 700px) {
+    .brm-row { flex-direction: column; }
+    .brm-list { flex: 1 1 auto; width: 100%; max-height: 14rem; }
+  }
+</style>
+
+<div class="brm-wrap">
+  <ul class="nav nav-tabs" role="tablist">
+    <li class="nav-item"><button class="nav-link active" data-tab="devices" type="button">Devices</button></li>
+    <li class="nav-item"><button class="nav-link" data-tab="accessories" type="button">Accessories</button></li>
+    <li class="nav-item"><button class="nav-link" data-tab="settings" type="button">Settings</button></li>
+  </ul>
+
+  <!-- ---------------------------------------------------------- devices -->
+  <div data-panel="devices">
+    <div class="brm-section">
+      <h6>Broadlink devices on this network</h6>
+      <p class="brm-hint">
+        A scan sends a broadcast that every Broadlink RM device answers, so it finds them
+        wherever they are. Nothing here is required: leave the list below empty and the
+        plugin discovers devices by itself each time it starts.
+      </p>
+      <button class="btn btn-primary btn-sm" id="brm-scan" type="button">Scan network</button>
+      <span class="brm-hint" id="brm-scan-status"></span>
+    </div>
+
+    <div id="brm-devices"></div>
+
+    <div class="brm-section">
+      <h6>Fixed addresses</h6>
+      <p class="brm-hint">
+        Pinning a device writes its address into <code>hosts</code>, which switches automatic
+        discovery off and uses only the devices listed here. Use it when broadcast traffic is
+        blocked between Homebridge and the device, for example across VLANs.
+      </p>
+      <div id="brm-hosts"></div>
+    </div>
+  </div>
+
+  <!-- ------------------------------------------------------ accessories -->
+  <div data-panel="accessories" hidden>
+    <div class="brm-row">
+      <div>
+        <div class="brm-list" id="brm-accessory-list"></div>
+        <button class="btn btn-outline-primary btn-sm mt-2 w-100" id="brm-add" type="button">Add accessory</button>
+      </div>
+      <div class="brm-editor" id="brm-accessory-editor"></div>
+    </div>
+  </div>
+
+  <!-- --------------------------------------------------------- settings -->
+  <div data-panel="settings" hidden>
+    <div class="brm-section">
+      <h6>Platform</h6>
+      <div id="brm-settings"></div>
+    </div>
+    <p class="brm-hint">
+      Every option is described at
+      <a href="https://broadlink.kiwicam.nz" target="_blank" rel="noopener">broadlink.kiwicam.nz</a>.
+      Changes are applied when you press Save.
+    </p>
+  </div>
+</div>
+
+<script src="js/options.js"></script>
+<script>
+  (function () {
+    'use strict';
+
+    var O = window.BroadlinkOptions;
+
+    // js/options.js holds every option this editor knows how to render. If it
+    // did not load there is nothing to draw, so say so rather than leaving an
+    // empty panel behind.
+    if (!O) {
+      document.querySelector('.brm-wrap').innerHTML =
+        '<div class="alert alert-danger">The configuration UI could not load one of its own files ' +
+        '(<code>js/options.js</code>). Reload the page; if it keeps happening, use the JSON editor ' +
+        'and open an issue with the browser console output.</div>';
+      return;
+    }
+    var config = null;
+    var selected = -1;
+    var lastScan = [];
+
+    var PLATFORM_FIELDS = [
+      { key: 'name', label: 'Name', type: 'text', default: 'Broadlink RM',
+        help: 'Used by Homebridge in its logs. Not shown in the Home app.' },
+      { key: 'logLevel', label: 'Log level', type: 'select', default: 'info', options: O.LOG_LEVELS,
+        help: 'How much detail the platform writes to the Homebridge log.' },
+      { key: 'deviceDiscoveryTimeout', label: 'Discovery timeout', type: 'number', unit: 'seconds', default: 60,
+        help: 'How long the network is scanned for devices at start-up.' },
+      { key: 'hideLearnButton', label: 'Hide the Learn accessory', type: 'boolean', default: false,
+        help: 'Stops the Learn switch, used to learn IR codes, being added to HomeKit.' },
+      { key: 'hideScanFrequencyButton', label: 'Hide the Scan Frequency accessory', type: 'boolean', default: false,
+        help: 'Stops the Scan Frequency switch, used to learn RF codes, being added to HomeKit.' },
+      { key: 'hideWelcomeMessage', label: 'Hide the welcome message', type: 'boolean', default: false,
+        help: 'Stops the welcome banner being written to the log at start-up.' }
+    ];
+
+    // ------------------------------------------------------------- helpers
+
+    function el(tag, attrs, children) {
+      var node = document.createElement(tag);
+      Object.keys(attrs || {}).forEach(function (key) {
+        if (key === 'class') { node.className = attrs[key]; }
+        else if (key === 'text') { node.textContent = attrs[key]; }
+        else if (key === 'html') { node.innerHTML = attrs[key]; }
+        else if (key.indexOf('on') === 0) { node.addEventListener(key.slice(2), attrs[key]); }
+        else if (attrs[key] !== null && attrs[key] !== undefined && attrs[key] !== false) { node.setAttribute(key, attrs[key]); }
+      });
+      (children || []).forEach(function (child) { if (child) { node.appendChild(child); } });
+      return node;
+    }
+
+    function stage() {
+      homebridge.updatePluginConfig([config]);
+    }
+
+    function currentValue(target, field) {
+      return target[field.key] === undefined ? field.default : target[field.key];
+    }
+
+    // Only non-default values are written, so a configuration stays readable and
+    // an option the plugin later changes the default of keeps following it.
+    function setValue(target, field, value) {
+      if (value === undefined || value === '' || value === null) { delete target[field.key]; }
+      else if (field.default !== undefined && value === field.default) { delete target[field.key]; }
+      else { target[field.key] = value; }
+      stage();
+    }
+
+    function fieldControl(target, field) {
+      var value = currentValue(target, field);
+      var id = 'brm-f-' + field.key + '-' + Math.random().toString(36).slice(2, 8);
+      var input;
+
+      if (field.type === 'boolean') {
+        input = el('input', { type: 'checkbox', class: 'form-check-input', id: id });
+        input.checked = value === true;
+        input.addEventListener('change', function () { setValue(target, field, input.checked); });
+
+        return el('div', { class: 'form-check mb-3' }, [
+          input,
+          el('label', { class: 'form-check-label', for: id, text: field.label }),
+          field.help ? el('p', { class: 'brm-hint', text: field.help }) : null
+        ]);
+      }
+
+      if (field.type === 'select') {
+        input = el('select', { class: 'form-select form-select-sm', id: id });
+        (field.options || []).forEach(function (option) {
+          input.appendChild(el('option', { value: option.value, text: option.label }));
+        });
+        input.value = value === undefined ? '' : value;
+        input.addEventListener('change', function () { setValue(target, field, input.value); });
+      } else if (field.type === 'stringList') {
+        input = el('input', { type: 'text', class: 'form-control form-control-sm', id: id, placeholder: 'Comma separated' });
+        input.value = Array.isArray(value) ? value.join(', ') : '';
+        input.addEventListener('change', function () {
+          var parts = input.value.split(',').map(function (part) { return part.trim(); }).filter(Boolean);
+          if (parts.length) { target[field.key] = parts; } else { delete target[field.key]; }
+          stage();
+        });
+      } else {
+        input = el('input', {
+          type: field.type === 'password' ? 'password' : (field.type === 'number' ? 'number' : 'text'),
+          class: 'form-control form-control-sm',
+          id: id,
+          step: field.type === 'number' ? 'any' : null,
+          placeholder: field.default === undefined ? '' : String(field.default)
+        });
+        input.value = value === undefined ? '' : value;
+        input.addEventListener('change', function () {
+          if (field.type === 'number') {
+            var num = input.value === '' ? undefined : Number(input.value);
+            setValue(target, field, isNaN(num) ? undefined : num);
+          } else {
+            setValue(target, field, input.value.trim());
+          }
+        });
+      }
+
+      return el('div', { class: 'mb-3' }, [
+        el('label', { class: 'form-label mb-1', for: id, text: field.label + (field.unit ? ' (' + field.unit + ')' : '') }),
+        input,
+        field.help ? el('p', { class: 'brm-hint', text: field.help }) : null
+      ]);
+    }
+
+    // -------------------------------------------------------------- devices
+
+    function isPinned(mac) {
+      return (config.hosts || []).some(function (host) {
+        return String(host.mac || '').toLowerCase() === mac;
+      });
+    }
+
+    function togglePin(device, pin) {
+      if (!config.hosts) { config.hosts = []; }
+
+      var index = config.hosts.findIndex(function (host) {
+        return String(host.mac || '').toLowerCase() === device.mac;
+      });
+
+      if (pin && index === -1) {
+        config.hosts.push({
+          address: device.address,
+          mac: device.mac,
+          isRFSupported: device.supportsRF === true,
+          isRM4: /RM4/i.test(device.model || '')
+        });
+      } else if (!pin && index !== -1) {
+        config.hosts.splice(index, 1);
+      }
+
+      if (!config.hosts.length) { delete config.hosts; }
+
+      stage();
+      renderDevices();
+      renderHosts();
+    }
+
+    function renderDevices() {
+      var container = document.getElementById('brm-devices');
+      container.innerHTML = '';
+
+      if (!lastScan.length) {
+        container.appendChild(el('div', { class: 'brm-empty', text: 'No scan run yet.' }));
+        return;
+      }
+
+      lastScan.forEach(function (device) {
+        var badges = [];
+
+        if (device.model) { badges.push(el('span', { class: 'badge bg-secondary', text: device.model })); }
+        if (device.supportsRF) { badges.push(el('span', { class: 'badge bg-info text-dark', text: 'IR + RF' })); }
+        else if (device.supportsLearning) { badges.push(el('span', { class: 'badge bg-info text-dark', text: 'IR' })); }
+        if (device.locked) { badges.push(el('span', { class: 'badge bg-danger', text: 'Locked' })); }
+        else if (device.linkLocal) { badges.push(el('span', { class: 'badge bg-danger', text: 'No DHCP lease' })); }
+        else if (!device.authenticated) { badges.push(el('span', { class: 'badge bg-warning text-dark', text: 'Did not respond' })); }
+        else { badges.push(el('span', { class: 'badge bg-success', text: 'Ready' })); }
+
+        var pinId = 'brm-pin-' + device.mac.replace(/:/g, '');
+        var pin = el('input', { type: 'checkbox', class: 'form-check-input', id: pinId });
+        pin.checked = isPinned(device.mac);
+        pin.addEventListener('change', function () { togglePin(device, pin.checked); });
+
+        var notes = [];
+
+        if (device.locked) {
+          notes.push(el('div', { class: 'alert alert-danger py-2 px-3 mt-2 mb-0', html:
+            'This device is locked to the Broadlink cloud and will not accept local connections. ' +
+            'Open the Broadlink app, tap the device, tap <strong>...</strong>, and switch ' +
+            '<strong>Lock device</strong> off.' }));
+        } else if (device.linkLocal) {
+          notes.push(el('div', { class: 'alert alert-danger py-2 px-3 mt-2 mb-0', html:
+            'This device never got an address from your router, so it answered on a link-local ' +
+            'address (<span class="brm-mono">' + device.address + '</span>). It can be seen by ' +
+            'broadcast but not reached directly. Reserve an address for it on the router and ' +
+            'power-cycle the device.' }));
+        } else if (!device.authenticated) {
+          notes.push(el('div', { class: 'alert alert-warning py-2 px-3 mt-2 mb-0', text:
+            'The device answered the scan but did not complete the handshake. It may still be starting up.' }));
+        }
+
+        container.appendChild(el('div', { class: 'brm-device' }, [
+          el('div', { class: 'brm-device-head' }, badges.concat([
+            el('span', { class: 'brm-mono ms-auto', text: device.address }),
+            el('span', { class: 'brm-mono', text: device.mac })
+          ])),
+          el('div', { class: 'form-check mt-2 mb-0' }, [
+            pin,
+            el('label', { class: 'form-check-label', for: pinId, text: 'Always use this address' })
+          ])
+        ].concat(notes)));
+      });
+    }
+
+    function renderHosts() {
+      var container = document.getElementById('brm-hosts');
+      container.innerHTML = '';
+
+      var hosts = config.hosts || [];
+
+      if (!hosts.length) {
+        container.appendChild(el('p', { class: 'brm-hint mb-0',
+          text: 'Empty. Devices are discovered automatically, which is the recommended setting.' }));
+        return;
+      }
+
+      hosts.forEach(function (host) {
+        container.appendChild(el('div', { class: 'd-flex align-items-center gap-2 mb-1' }, [
+          el('span', { class: 'brm-mono', text: host.address }),
+          el('span', { class: 'brm-mono', text: host.mac }),
+          el('button', {
+            class: 'btn btn-outline-danger btn-sm ms-auto', type: 'button', text: 'Remove',
+            onclick: function () { togglePin({ mac: String(host.mac || '').toLowerCase() }, false); }
+          })
+        ]));
+      });
+    }
+
+    function scan() {
+      var status = document.getElementById('brm-scan-status');
+      var button = document.getElementById('brm-scan');
+
+      button.disabled = true;
+      status.textContent = ' Scanning, this takes about 12 seconds...';
+      homebridge.showSpinner();
+
+      homebridge.request('/discover', { seconds: 12 }).then(function (result) {
+        lastScan = result.devices || [];
+        status.textContent = lastScan.length
+          ? ' Found ' + lastScan.length + ' device' + (lastScan.length === 1 ? '' : 's') + '.'
+          : ' No devices answered.';
+        if (!lastScan.length) {
+          homebridge.toast.warning('Check that the device is powered on and on the same network as Homebridge.', 'No devices found');
+        }
+        renderDevices();
+      }).catch(function (err) {
+        status.textContent = '';
+        homebridge.toast.error(err.message || 'The scan failed.', 'Scan failed');
+      }).then(function () {
+        button.disabled = false;
+        homebridge.hideSpinner();
+        homebridge.fixScrollHeight();
+      });
+    }
+
+    // ---------------------------------------------------------- accessories
+
+    function accessories() {
+      if (!Array.isArray(config.accessories)) { config.accessories = []; }
+      return config.accessories;
+    }
+
+    function renderList() {
+      var container = document.getElementById('brm-accessory-list');
+      container.innerHTML = '';
+
+      var list = accessories();
+
+      if (!list.length) {
+        container.appendChild(el('div', { class: 'brm-empty', text: 'No accessories yet.' }));
+        return;
+      }
+
+      list.forEach(function (accessory, index) {
+        container.appendChild(el('button', {
+          type: 'button',
+          class: index === selected ? 'active' : '',
+          onclick: function () { selected = index; renderList(); renderEditor(); }
+        }, [
+          document.createTextNode(accessory.name || 'Unnamed'),
+          el('span', { class: 'brm-list-type', text: O.typeLabel(accessory.type) })
+        ]));
+      });
+    }
+
+    function deviceChoices() {
+      var seen = {};
+      var choices = [{ value: '', label: 'Any device found' }];
+
+      lastScan.forEach(function (device) {
+        seen[device.mac] = true;
+        choices.push({ value: device.mac, label: (device.model || 'Broadlink') + ' - ' + device.mac + ' (' + device.address + ')' });
+      });
+
+      (config.hosts || []).forEach(function (host) {
+        var mac = String(host.mac || '').toLowerCase();
+        if (mac && !seen[mac]) {
+          seen[mac] = true;
+          choices.push({ value: mac, label: mac + ' (' + host.address + ')' });
+        }
+      });
+
+      accessories().forEach(function (accessory) {
+        if (accessory.host && !seen[accessory.host]) {
+          seen[accessory.host] = true;
+          choices.push({ value: accessory.host, label: accessory.host + ' (from the current configuration)' });
+        }
+      });
+
+      return choices;
+    }
+
+    // --------------------------------------------------------------- codes
+
+    var learnTarget = null;   // { accessory, path, label }
+    var learnQueue = [];      // remaining slots when learning a whole remote
+    var learnStrip = null;
+
+    function accessoryDevice(accessory) {
+      if (accessory.host) { return accessory.host; }
+      return lastScan.length ? lastScan[0].mac : null;
+    }
+
+    function deviceRecord(mac) {
+      for (var i = 0; i < lastScan.length; i += 1) {
+        if (lastScan[i].mac === mac) { return lastScan[i]; }
+      }
+      return null;
+    }
+
+    function stopLearning(quiet) {
+      learnTarget = null;
+      learnQueue = [];
+      homebridge.request('/learn/stop').catch(function () {});
+      if (!quiet) { renderEditor(); }
+    }
+
+    function beginLearning(accessory, slot, mode, queue) {
+      var mac = accessoryDevice(accessory);
+
+      if (!mac) {
+        homebridge.toast.error('Run a scan on the Devices tab first, or set a device for this accessory.', 'No device');
+        return;
+      }
+
+      learnTarget = { accessory: accessory, path: slot.path, label: slot.label, mode: mode };
+      learnQueue = queue || [];
+      renderEditor();
+
+      homebridge.request('/learn/start', {
+        mac: mac,
+        mode: mode,
+        continuous: learnQueue.length > 0
+      }).catch(function (err) {
+        learnTarget = null;
+        learnQueue = [];
+        homebridge.toast.error(err.message || 'Could not start learning.', 'Learning');
+        renderEditor();
+      });
+    }
+
+    function setLearnState(text) {
+      if (learnStrip) { learnStrip.textContent = text; }
+    }
+
+    homebridge.addEventListener('learn-status', function (event) {
+      var data = event.data || {};
+      if (!learnTarget) { return; }
+
+      if (data.state === 'timeout' || data.state === 'stopped') {
+        if (data.state === 'timeout') {
+          homebridge.toast.warning(data.message || 'Nothing was received.', 'Learning stopped');
+        }
+        learnTarget = null;
+        learnQueue = [];
+        renderEditor();
+        return;
+      }
+
+      setLearnState(data.message || '');
+    });
+
+    homebridge.addEventListener('learn-code', function (event) {
+      if (!learnTarget) { return; }
+
+      var hex = (event.data || {}).hex;
+      if (!hex) { return; }
+
+      var accessory = learnTarget.accessory;
+      if (!accessory.data || typeof accessory.data !== 'object') { accessory.data = {}; }
+
+      O.writeCode(accessory.data, learnTarget.path, hex);
+      stage();
+
+      homebridge.toast.success(learnTarget.label + ' learned.', 'Code received');
+
+      // When learning a whole remote, move straight on to the next empty slot
+      // and let the server keep the device in learning mode.
+      var next = learnQueue.shift();
+
+      if (next) {
+        learnTarget = { accessory: accessory, path: next.path, label: next.label, mode: learnTarget.mode };
+        renderEditor();
+        return;
+      }
+
+      learnTarget = null;
+      homebridge.request('/learn/stop').catch(function () {});
+      renderEditor();
+    });
+
+    function codeRow(accessory, slot) {
+      var data = accessory.data && typeof accessory.data === 'object' ? accessory.data : {};
+      var hex = O.readCode(data, slot.path);
+      var isTarget = learnTarget && learnTarget.accessory === accessory && learnTarget.path === slot.path;
+
+      var buttons = [];
+      var mac = accessoryDevice(accessory);
+      var record = mac ? deviceRecord(mac) : null;
+
+      buttons.push(el('button', {
+        class: 'btn btn-outline-primary', type: 'button', text: hex ? 'Relearn' : 'Learn',
+        onclick: function () { beginLearning(accessory, slot, 'ir', []); }
+      }));
+
+      if (!record || record.supportsRF) {
+        buttons.push(el('button', {
+          class: 'btn btn-outline-primary', type: 'button', text: 'Learn RF',
+          onclick: function () { beginLearning(accessory, slot, 'rf', []); }
+        }));
+      }
+
+      if (hex && /^[0-9a-fA-F]+$/.test(hex)) {
+        buttons.push(el('button', {
+          class: 'btn', type: 'button', text: 'Test',
+          onclick: function () {
+            homebridge.request('/send', { mac: mac, hex: hex }).then(function () {
+              homebridge.toast.success('Sent ' + slot.label + '.', 'Test');
+            }).catch(function (err) {
+              homebridge.toast.error(err.message || 'Could not send the code.', 'Test');
+            });
+          }
+        }));
+      }
+
+      if (hex) {
+        buttons.push(el('button', {
+          class: 'btn btn-outline-danger', type: 'button', text: 'Clear',
+          onclick: function () {
+            O.writeCode(accessory.data || {}, slot.path, null);
+            stage();
+            renderEditor();
+          }
+        }));
+      }
+
+      return el('div', { class: 'brm-code' + (isTarget ? ' is-target' : '') }, [
+        el('span', { class: 'brm-code-label', text: slot.label }),
+        hex
+          ? el('span', { class: 'brm-mono brm-code-hex', text: hex })
+          : el('span', { class: 'badge ' + (slot.optional ? 'bg-secondary' : 'bg-warning text-dark'),
+              text: slot.optional ? 'Optional' : 'Not set' }),
+        el('span', { class: 'd-flex gap-2 ms-auto' }, buttons)
+      ]);
+    }
+
+    function familyPicker(accessory) {
+      var families = O.CODE_FAMILIES[accessory.type];
+      if (!families || !families.length) { return null; }
+
+      var familySelect = el('select', { class: 'form-select form-select-sm' });
+      families.forEach(function (family) {
+        familySelect.appendChild(el('option', { value: family.id, text: family.label }));
+      });
+
+      var number = el('input', { type: 'number', class: 'form-control form-control-sm' });
+      var mode = el('select', { class: 'form-select form-select-sm' });
+      [['cool', 'Cooling'], ['heat', 'Heating'], ['auto', 'Auto'], ['', 'No mode']].forEach(function (pair) {
+        mode.appendChild(el('option', { value: pair[0], text: pair[1] }));
+      });
+
+      var syncFamily = function () {
+        var family = families.filter(function (f) { return f.id === familySelect.value; })[0];
+        number.min = family.min;
+        number.max = family.max;
+        number.step = family.step;
+        if (!number.value) { number.value = family.min; }
+        mode.parentNode.hidden = !family.mode;
+      };
+
+      familySelect.addEventListener('change', syncFamily);
+
+      var modeWrap = el('div', {}, [
+        el('label', { class: 'form-label mb-1', text: 'Mode' }),
+        mode
+      ]);
+
+      var add = el('button', {
+        class: 'btn btn-outline-primary btn-sm', type: 'button', text: 'Add',
+        onclick: function () {
+          var family = families.filter(function (f) { return f.id === familySelect.value; })[0];
+          var value = Number(number.value);
+
+          if (isNaN(value)) {
+            homebridge.toast.error('Enter a number first.', 'Add a code');
+            return;
+          }
+
+          if (!accessory.data || typeof accessory.data !== 'object') { accessory.data = {}; }
+
+          var key = family.key(value);
+
+          if (accessory.data[key] !== undefined) {
+            homebridge.toast.info('That code is already in the list.', 'Add a code');
+            return;
+          }
+
+          // A temperature slot carries the mode it puts the unit into, so it is
+          // created as an object and learning fills in its "data".
+          if (family.mode && mode.value) {
+            accessory.data[key] = { 'pseudo-mode': mode.value, data: '' };
+          } else {
+            accessory.data[key] = '';
+          }
+
+          stage();
+          renderEditor();
+        }
+      });
+
+      var wrap = el('div', { class: 'brm-add' }, [
+        el('div', {}, [el('label', { class: 'form-label mb-1', text: 'Add a code' }), familySelect]),
+        el('div', {}, [el('label', { class: 'form-label mb-1', text: 'Value' }), number]),
+        modeWrap,
+        add
+      ]);
+
+      syncFamily();
+
+      return wrap;
+    }
+
+    function renderCodesEditor(accessory) {
+      if (O.DATA_TYPES.indexOf(accessory.type) === -1) { return null; }
+
+      var slots = O.slotsFor(accessory);
+      var data = accessory.data && typeof accessory.data === 'object' ? accessory.data : {};
+
+      var children = [
+        el('h6', { text: 'Codes' }),
+        el('p', { class: 'brm-hint', text:
+          'Press Learn, then press the button on the original remote while pointing it at the ' +
+          'Broadlink device. The code is written straight into the accessory - there is no need to ' +
+          'copy anything out of the log.' })
+      ];
+
+      // The live learning strip, shown only while a capture is running.
+      if (learnTarget && learnTarget.accessory === accessory) {
+        learnStrip = el('p', { class: 'brm-hint mb-0', text: 'Starting...' });
+
+        children.push(el('div', { class: 'brm-learn' }, [
+          el('p', { class: 'brm-learn-state mb-0',
+            text: (learnTarget.mode === 'rf' ? 'Learning RF: ' : 'Learning: ') + learnTarget.label }),
+          learnStrip,
+          learnQueue.length
+            ? el('p', { class: 'brm-hint mb-0', text: learnQueue.length + ' more to go after this one.' })
+            : null,
+          el('button', {
+            class: 'btn btn-outline-danger btn-sm mt-2', type: 'button', text: 'Stop',
+            onclick: function () { stopLearning(); }
+          })
+        ]));
+      } else {
+        learnStrip = null;
+
+        var empty = slots.filter(function (slot) {
+          return !slot.optional && !O.readCode(data, slot.path);
+        });
+
+        if (empty.length) {
+          children.push(el('div', { class: 'mb-3' }, [
+            el('button', {
+              class: 'btn btn-primary btn-sm', type: 'button',
+              text: 'Learn the ' + empty.length + ' missing code' + (empty.length === 1 ? '' : 's'),
+              onclick: function () {
+                var queue = empty.slice(1);
+                beginLearning(accessory, empty[0], 'ir', queue);
+              }
+            }),
+            el('p', { class: 'brm-hint mb-0', text:
+              'Walks through them one at a time, keeping the device in learning mode between presses. IR only.' })
+          ]));
+        }
+      }
+
+      // Group the slots under their headings, in the order the catalogue lists.
+      var order = [];
+      var grouped = {};
+
+      slots.forEach(function (slot) {
+        var group = slot.group || 'Codes';
+        if (!grouped[group]) { grouped[group] = []; order.push(group); }
+        grouped[group].push(slot);
+      });
+
+      order.forEach(function (group) {
+        children.push(el('div', { class: 'brm-group' }, [el('span', { text: group })].concat(
+          grouped[group].map(function (slot) { return codeRow(accessory, slot); })
+        )));
+      });
+
+      var picker = familyPicker(accessory);
+      if (picker) { children.push(picker); }
+
+      children.push(rawDataEditor(accessory));
+
+      return el('div', { class: 'brm-section' }, children);
+    }
+
+    // The full data object stays editable by hand, for shapes the slot list
+    // does not model - repeated codes, code lists, TV inputs.
+    function rawDataEditor(accessory) {
+      var textarea = el('textarea', { class: 'form-control brm-data', spellcheck: 'false' });
+      textarea.value = JSON.stringify(accessory.data === undefined ? {} : accessory.data, null, 2);
+
+      var error = el('p', { class: 'brm-hint text-danger', text: '' });
+
+      textarea.addEventListener('change', function () {
+        var text = textarea.value.trim();
+
+        if (!text) {
+          delete accessory.data;
+          error.textContent = '';
+          stage();
+          return;
+        }
+
+        try {
+          accessory.data = JSON.parse(text);
+          error.textContent = '';
+          stage();
+          renderEditor();
+        } catch (err) {
+          error.textContent = 'Not valid JSON, so this was not saved: ' + err.message;
+        }
+      });
+
+      var template = O.DATA_TEMPLATES[accessory.type];
+      var extras = [];
+
+      if (template && (accessory.data === undefined || !Object.keys(accessory.data || {}).length)) {
+        extras.push(el('button', {
+          class: 'btn btn-outline-secondary btn-sm mt-2', type: 'button', text: 'Insert a starting template',
+          onclick: function () {
+            accessory.data = JSON.parse(JSON.stringify(template));
+            stage();
+            renderEditor();
+          }
+        }));
+      }
+
+      return el('details', { class: 'brm-raw' }, [
+        el('summary', { text: 'Edit the raw code data' }),
+        el('p', { class: 'brm-hint', html:
+          'The shape of this object depends on the accessory type - see ' +
+          '<a href="https://broadlink.kiwicam.nz" target="_blank" rel="noopener">the documentation</a>.' }),
+        textarea,
+        error
+      ].concat(extras));
+    }
+
+    function renderEditor() {
+      var container = document.getElementById('brm-accessory-editor');
+      container.innerHTML = '';
+
+      var list = accessories();
+
+      if (selected < 0 || selected >= list.length) {
+        container.appendChild(el('div', { class: 'brm-empty', text: 'Select an accessory, or add one.' }));
+        return;
+      }
+
+      var accessory = list[selected];
+
+      var nameField = fieldControl(accessory, { key: 'name', label: 'Name', type: 'text',
+        help: 'Shown in the Home app. Changing it creates a new accessory in HomeKit.' });
+
+      var typeSelect = el('select', { class: 'form-select form-select-sm' });
+      O.ACCESSORY_TYPES.forEach(function (type) {
+        typeSelect.appendChild(el('option', { value: type.value, text: type.label }));
+      });
+      typeSelect.value = accessory.type || 'switch';
+
+      var typeHint = el('p', { class: 'brm-hint', text: '' });
+      var describeType = function () {
+        var match = O.ACCESSORY_TYPES.filter(function (type) { return type.value === typeSelect.value; })[0];
+        typeHint.textContent = match ? match.hint : '';
+      };
+      describeType();
+
+      typeSelect.addEventListener('change', function () {
+        accessory.type = typeSelect.value;
+        stage();
+        renderList();
+        renderEditor();
+      });
+
+      container.appendChild(el('div', { class: 'brm-section' }, [
+        el('h6', { text: 'Identity' }),
+        nameField,
+        el('div', { class: 'mb-3' }, [
+          el('label', { class: 'form-label mb-1', text: 'Type' }),
+          typeSelect,
+          typeHint
+        ])
+      ]));
+
+      // Group the options that apply to this accessory type.
+      var applicable = O.optionsFor(accessory.type);
+
+      O.GROUPS.forEach(function (group) {
+        var fields = applicable.filter(function (option) { return option.group === group.id; });
+        if (!fields.length) { return; }
+
+        var body = fields.map(function (field) {
+          if (field.type === 'device') {
+            return fieldControl(accessory, {
+              key: 'host', label: field.label, type: 'select', help: field.help,
+              options: deviceChoices()
+            });
+          }
+          return fieldControl(accessory, field);
+        });
+
+        container.appendChild(el('div', { class: 'brm-section' }, [el('h6', { text: group.label })].concat(body)));
+      });
+
+      var dataEditor = renderCodesEditor(accessory);
+      if (dataEditor) { container.appendChild(dataEditor); }
+
+      container.appendChild(el('div', { class: 'd-flex gap-2' }, [
+        el('button', {
+          class: 'btn btn-outline-secondary btn-sm', type: 'button', text: 'Duplicate',
+          onclick: function () {
+            var copy = JSON.parse(JSON.stringify(accessory));
+            copy.name = (copy.name || 'Accessory') + ' copy';
+            accessories().splice(selected + 1, 0, copy);
+            selected += 1;
+            stage();
+            renderList();
+            renderEditor();
+          }
+        }),
+        el('button', {
+          class: 'btn btn-outline-danger btn-sm ms-auto', type: 'button', text: 'Delete',
+          onclick: function () {
+            if (!window.confirm('Delete "' + (accessory.name || 'this accessory') + '"?')) { return; }
+            accessories().splice(selected, 1);
+            selected = -1;
+            stage();
+            renderList();
+            renderEditor();
+          }
+        })
+      ]));
+
+      homebridge.fixScrollHeight();
+    }
+
+    function addAccessory() {
+      accessories().push({ name: 'New accessory', type: 'switch' });
+      selected = accessories().length - 1;
+      stage();
+      renderList();
+      renderEditor();
+    }
+
+    // --------------------------------------------------------------- settings
+
+    function renderSettings() {
+      var container = document.getElementById('brm-settings');
+      container.innerHTML = '';
+      PLATFORM_FIELDS.forEach(function (field) {
+        container.appendChild(fieldControl(config, field));
+      });
+    }
+
+    // ------------------------------------------------------------------- init
+
+    function showTab(name) {
+      document.querySelectorAll('[data-tab]').forEach(function (button) {
+        button.classList.toggle('active', button.getAttribute('data-tab') === name);
+      });
+      document.querySelectorAll('[data-panel]').forEach(function (panel) {
+        panel.hidden = panel.getAttribute('data-panel') !== name;
+      });
+      homebridge.fixScrollHeight();
+    }
+
+    document.querySelectorAll('[data-tab]').forEach(function (button) {
+      button.addEventListener('click', function () { showTab(button.getAttribute('data-tab')); });
+    });
+
+    document.getElementById('brm-scan').addEventListener('click', scan);
+    document.getElementById('brm-add').addEventListener('click', addAccessory);
+
+    homebridge.getPluginConfig().then(function (blocks) {
+      config = blocks[0] || { platform: 'BroadlinkRM', name: 'Broadlink RM', accessories: [] };
+      if (!config.platform) { config.platform = 'BroadlinkRM'; }
+
+      renderDevices();
+      renderHosts();
+      renderList();
+      renderEditor();
+      renderSettings();
+
+      stage();
+      homebridge.fixScrollHeight();
+    }).catch(function (err) {
+      homebridge.toast.error(err.message || 'Could not read the current configuration.', 'Configuration');
+      document.querySelector('.brm-wrap').insertAdjacentHTML('afterbegin',
+        '<div class="alert alert-danger">Could not read the current configuration: ' +
+        (err.message || 'unknown error') + '</div>');
+    });
+  }());
+</script>

--- a/homebridge-ui/public/js/options.js
+++ b/homebridge-ui/public/js/options.js
@@ -1,0 +1,533 @@
+/**
+ * Option catalogue for the Broadlink RM custom configuration UI.
+ *
+ * Every entry mirrors an option the plugin implements, as documented at
+ * https://broadlink.kiwicam.nz. Adding an option here is all that is needed for
+ * it to appear in the accessory editor.
+ *
+ *   key     - the config.json property name
+ *   label   - shown next to the control
+ *   type    - boolean | number | text | select | stringList
+ *   help    - one line explaining what it does
+ *   group   - which section of the editor it belongs to
+ *   types   - accessory types the option applies to
+ *   unit    - optional suffix shown after a number input
+ */
+
+(function (global) {
+  'use strict';
+
+  var ACCESSORY_TYPES = [
+    { value: 'switch', label: 'Switch', hint: 'On/off control for anything with a separate on and off code.' },
+    { value: 'outlet', label: 'Outlet', hint: 'Like a switch, but shown as a plug in the Home app.' },
+    { value: 'light', label: 'Light', hint: 'Brightness and colour, using one code per level.' },
+    { value: 'fan', label: 'Fan', hint: 'Speed, swing and rotation direction.' },
+    { value: 'fanv1', label: 'Fan (classic)', hint: 'Older fan service. Use "Fan" unless you need the legacy behaviour.' },
+    { value: 'air-purifier', label: 'Air purifier', hint: 'Purifier with optional swing and child lock.' },
+    { value: 'air-conditioner', label: 'Air conditioner', hint: 'Thermostat with one code per temperature.' },
+    { value: 'heater-cooler', label: 'Heater / cooler', hint: 'Heater-cooler service with per-temperature fan speed and swing codes.' },
+    { value: 'humidifier-dehumidifier', label: 'Humidifier / dehumidifier', hint: 'Humidifier, dehumidifier, or both.' },
+    { value: 'temperatureSensor', label: 'Temperature sensor', hint: 'Reports temperature from the RM device, a file, or MQTT.' },
+    { value: 'humiditySensor', label: 'Humidity sensor', hint: 'Reports humidity from the RM device, a file, or MQTT.' },
+    { value: 'garage-door-opener', label: 'Garage door opener', hint: 'Open and close with a travel time.' },
+    { value: 'lock', label: 'Lock', hint: 'Lock and unlock with a travel time.' },
+    { value: 'window-covering', label: 'Window covering', hint: 'Blinds and curtains, positioned by travel time.' },
+    { value: 'window', label: 'Window', hint: 'Like a window covering, shown as a window in the Home app.' },
+    { value: 'tv', label: 'TV', hint: 'Full TV remote with inputs, volume and directional buttons.' },
+    { value: 'switch-multi', label: 'Switch (multiple codes)', hint: 'Sends a list of codes in order when switched on.' },
+    { value: 'switch-multi-repeat', label: 'Switch (multiple, repeated)', hint: 'Sends a list of codes, repeated a number of times.' },
+    { value: 'switch-repeat', label: 'Switch (repeated code)', hint: 'Sends the same code several times, useful for stubborn devices.' },
+    { value: 'learn-code', label: 'Learn code', hint: 'A switch that puts the RM device into learning mode and writes the code to the log.' },
+    { value: 'learn-ir', label: 'Learn code (alias)', hint: 'Identical to "Learn code". Kept for older configurations.' }
+  ];
+
+  var LOG_LEVELS = [
+    { value: 'none', label: 'None' },
+    { value: 'critical', label: 'Critical' },
+    { value: 'error', label: 'Error' },
+    { value: 'warning', label: 'Warning' },
+    { value: 'info', label: 'Info (default)' },
+    { value: 'debug', label: 'Debug' },
+    { value: 'trace', label: 'Trace' }
+  ];
+
+  var GROUPS = [
+    { id: 'general', label: 'General' },
+    { id: 'behaviour', label: 'Behaviour' },
+    { id: 'ping', label: 'Presence detection (ping)' },
+    { id: 'temperature', label: 'Temperature' },
+    { id: 'humidity', label: 'Humidity' },
+    { id: 'mqtt', label: 'MQTT and external readings' },
+    { id: 'advanced', label: 'Advanced' }
+  ];
+
+  // Accessory type groupings reused below.
+  var SWITCH_LIKE = ['switch', 'outlet', 'light', 'fan', 'fanv1', 'tv'];
+  var PING_TYPES = ['switch', 'outlet', 'fan', 'tv'];
+  var AUTO_TYPES = ['switch', 'outlet', 'light', 'fan', 'fanv1', 'tv', 'air-conditioner', 'learn-code', 'learn-ir'];
+  var CLIMATE = ['air-conditioner', 'heater-cooler'];
+  var HUMIDITY_TYPES = ['air-conditioner', 'heater-cooler', 'humidifier-dehumidifier', 'temperatureSensor', 'humiditySensor'];
+  var HISTORY_TYPES = ['air-conditioner', 'heater-cooler', 'humidifier-dehumidifier', 'temperatureSensor', 'humiditySensor'];
+  var ALL = ACCESSORY_TYPES.map(function (t) { return t.value; });
+
+  var OPTIONS = [
+    // ---------------------------------------------------------------- general
+    { key: 'host', label: 'Broadlink device', type: 'device', group: 'general', types: ALL,
+      help: 'Which RM device sends this accessory\'s codes. Leave empty to use the first device found.' },
+    { key: 'disabled', label: 'Disabled', type: 'boolean', group: 'general', types: ALL, default: false,
+      help: 'Keeps the configuration but stops the accessory being added to HomeKit.' },
+    { key: 'subType', label: 'Shown in Home as', type: 'select', group: 'general', types: ['tv'], default: 'tv',
+      options: [{ value: 'tv', label: 'TV' }, { value: 'stb', label: 'Set-top box' }, { value: 'stick', label: 'Streaming stick' }, { value: 'receiver', label: 'Receiver' }],
+      help: 'Changes the icon and wording used by the Home app.' },
+
+    // -------------------------------------------------------------- behaviour
+    { key: 'enableAutoOff', label: 'Turn off automatically', type: 'boolean', group: 'behaviour', types: AUTO_TYPES, default: false,
+      help: 'Switches the accessory off by itself once the on duration has passed.' },
+    { key: 'onDuration', label: 'On duration', type: 'number', unit: 'seconds', group: 'behaviour', types: AUTO_TYPES, default: 60,
+      help: 'How long to stay on before switching off automatically.' },
+    { key: 'enableAutoOn', label: 'Turn on automatically', type: 'boolean', group: 'behaviour', types: ['switch', 'outlet', 'light', 'fan', 'fanv1', 'tv'], default: false,
+      help: 'Switches the accessory on by itself once the off duration has passed.' },
+    { key: 'offDuration', label: 'Off duration', type: 'number', unit: 'seconds', group: 'behaviour', types: ['switch', 'outlet', 'light', 'fan', 'fanv1', 'tv'], default: 60,
+      help: 'How long to stay off before switching on automatically.' },
+    { key: 'stateless', label: 'Stateless', type: 'boolean', group: 'behaviour', types: ['switch'], default: false,
+      help: 'Always falls back to "off" after being triggered, like a button.' },
+
+    { key: 'defaultBrightness', label: 'Default brightness', type: 'number', unit: '%', group: 'behaviour', types: ['light'], default: 100,
+      help: 'Brightness used when the light is turned on and no level has been set.' },
+    { key: 'useLastKnownBrightness', label: 'Use last known brightness', type: 'boolean', group: 'behaviour', types: ['light'], default: true,
+      help: 'Restores the previous brightness instead of the default when turning the light on.' },
+    { key: 'onDelay', label: 'Delay after the on code', type: 'number', unit: 'seconds', group: 'behaviour', types: ['light'], default: 0.1,
+      help: 'Gap between the on code and the brightness or hue code that follows it.' },
+    { key: 'exclusives', label: 'Turn these off', type: 'stringList', group: 'behaviour', types: ['light'],
+      help: 'Names of other light accessories to switch off when this one is switched on.' },
+
+    { key: 'hideSwingMode', label: 'Hide swing control', type: 'boolean', group: 'behaviour', types: ['fan', 'air-purifier', 'humidifier-dehumidifier'], default: false,
+      help: 'Removes the swing control from the Home app.' },
+    { key: 'hideRotationDirection', label: 'Hide rotation direction', type: 'boolean', group: 'behaviour', types: ['fan', 'fanv1', 'air-purifier', 'humidifier-dehumidifier'], default: false,
+      help: 'Removes the clockwise / counter-clockwise control from the Home app.' },
+    { key: 'showLockPhysicalControls', label: 'Show child lock', type: 'boolean', group: 'behaviour', types: ['air-purifier', 'humidifier-dehumidifier'], default: true,
+      help: 'Shows the physical controls lock in the Home app.' },
+    { key: 'alwaysResetToDefaults', label: 'Reset speed when turned off', type: 'boolean', group: 'behaviour', types: ['fan', 'fanv1'], default: false,
+      help: 'Puts the speed back to its default every time the fan is switched off.' },
+    { key: 'defaultFanSpeed', label: 'Default speed', type: 'number', unit: '%', group: 'behaviour', types: ['fan', 'fanv1'], default: 100,
+      help: 'Speed used when the fan is turned on and no speed has been set.' },
+    { key: 'stepSize', label: 'Speed step size', type: 'number', unit: '%', group: 'behaviour', types: ['fan', 'fanv1', 'humidifier-dehumidifier'], default: 1,
+      help: 'How much the speed moves each time it is adjusted.' },
+    { key: 'speedCycle', label: 'Cycle through speeds', type: 'boolean', group: 'behaviour', types: ['fan'], default: false,
+      help: 'Wraps around to the lowest speed after the highest.' },
+    { key: 'speedSteps', label: 'Number of speeds', type: 'number', group: 'behaviour', types: ['fan'],
+      help: 'Use when the fan has a fixed number of speeds rather than a percentage.' },
+    { key: 'defaultSpeedStep', label: 'Default speed step', type: 'number', group: 'behaviour', types: ['fan'],
+      help: 'Which of the fixed speeds to use when none has been set.' },
+
+    { key: 'openCloseDuration', label: 'Travel time', type: 'number', unit: 'seconds', group: 'behaviour', types: ['garage-door-opener'], default: 8,
+      help: 'How long the door shows as opening or closing.' },
+    { key: 'openDuration', label: 'Opening time', type: 'number', unit: 'seconds', group: 'behaviour', types: ['garage-door-opener'],
+      help: 'Overrides the travel time for opening only.' },
+    { key: 'closeDuration', label: 'Closing time', type: 'number', unit: 'seconds', group: 'behaviour', types: ['garage-door-opener'],
+      help: 'Overrides the travel time for closing only.' },
+    { key: 'autoCloseDelay', label: 'Close automatically after', type: 'number', unit: 'seconds', group: 'behaviour', types: ['garage-door-opener'], default: 30,
+      help: 'Starts closing by itself once this time has passed.' },
+
+    { key: 'autoLockDelay', label: 'Lock automatically after', type: 'number', unit: 'seconds', group: 'behaviour', types: ['lock'], default: 30,
+      help: 'Locks by itself once this time has passed.' },
+    { key: 'lockDuration', label: 'Locking time', type: 'number', unit: 'seconds', group: 'behaviour', types: ['lock'], default: 1,
+      help: 'How long the lock shows as "locking".' },
+    { key: 'unlockDuration', label: 'Unlocking time', type: 'number', unit: 'seconds', group: 'behaviour', types: ['lock'], default: 1,
+      help: 'How long the lock shows as "unlocking".' },
+
+    { key: 'totalDurationOpen', label: 'Time to open fully', type: 'number', unit: 'seconds', group: 'behaviour', types: ['window-covering', 'window'],
+      help: 'Used to work out the position shown in the Home app.' },
+    { key: 'totalDurationClose', label: 'Time to close fully', type: 'number', unit: 'seconds', group: 'behaviour', types: ['window-covering', 'window'],
+      help: 'Used to work out the position shown in the Home app.' },
+    { key: 'initialDelay', label: 'Start delay', type: 'number', unit: 'seconds', group: 'behaviour', types: ['window-covering', 'window'], default: 0.1,
+      help: 'Offsets this accessory so several coverings moving at once do not interfere with each other.' },
+    { key: 'sendStopAt0', label: 'Send stop at 0%', type: 'boolean', group: 'behaviour', types: ['window-covering', 'window'], default: false,
+      help: 'Sends the stop code when the covering reaches fully closed.' },
+    { key: 'sendStopAt100', label: 'Send stop at 100%', type: 'boolean', group: 'behaviour', types: ['window-covering', 'window'], default: false,
+      help: 'Sends the stop code when the covering reaches fully open.' },
+
+    { key: 'interval', label: 'Gap between codes', type: 'number', unit: 'seconds', group: 'behaviour', types: ['switch-multi', 'switch-multi-repeat', 'switch-repeat'],
+      help: 'How long to wait between each code that is sent.' },
+    { key: 'sendCount', label: 'Times to send', type: 'number', group: 'behaviour', types: ['switch-repeat', 'switch-multi-repeat'], default: 1,
+      help: 'How many times the code is repeated.' },
+    { key: 'onSendCount', label: 'Times to send (on)', type: 'number', group: 'behaviour', types: ['switch-repeat'],
+      help: 'Overrides the repeat count for the on code.' },
+    { key: 'offSendCount', label: 'Times to send (off)', type: 'number', group: 'behaviour', types: ['switch-repeat'],
+      help: 'Overrides the repeat count for the off code.' },
+    { key: 'pause', label: 'Pause between repeats', type: 'number', unit: 'seconds', group: 'behaviour', types: ['switch-multi-repeat'],
+      help: 'How long to wait before starting the list again.' },
+
+    { key: 'scanFrequency', label: 'Learn RF instead of IR', type: 'boolean', group: 'behaviour', types: ['learn-code', 'learn-ir'], default: false,
+      help: 'Switches this accessory to the RF frequency sweep used for radio remotes.' },
+
+    // ------------------------------------------------------------------- ping
+    { key: 'pingIPAddress', label: 'IP address to watch', type: 'text', group: 'ping', types: PING_TYPES,
+      help: 'The accessory shows as on while this address answers, and off when it stops.' },
+    { key: 'pingUseArp', label: 'Use ARP instead of ping', type: 'boolean', group: 'ping', types: PING_TYPES, default: false,
+      help: 'Checks the address in the ARP table. Useful for devices that ignore ICMP.' },
+    { key: 'pingIPAddressStateOnly', label: 'Status only', type: 'boolean', group: 'ping', types: PING_TYPES, default: false,
+      help: 'Reflects the state in HomeKit without sending any code when it changes.' },
+    { key: 'pingFrequency', label: 'Check every', type: 'number', unit: 'seconds', group: 'ping', types: PING_TYPES, default: 1,
+      help: 'How often the address is checked.' },
+    { key: 'pingGrace', label: 'Grace period', type: 'number', unit: 'seconds', group: 'ping', types: PING_TYPES, default: 10,
+      help: 'Ignores state changes for this long after a command, giving the device time to start up or shut down.' },
+
+    // ------------------------------------------------------------ temperature
+    { key: 'minTemperature', label: 'Minimum temperature', type: 'number', group: 'temperature', types: CLIMATE,
+      help: 'Lowest temperature that can be requested.' },
+    { key: 'maxTemperature', label: 'Maximum temperature', type: 'number', group: 'temperature', types: CLIMATE,
+      help: 'Highest temperature that can be requested.' },
+    { key: 'tempStepSize', label: 'Temperature step size', type: 'number', group: 'temperature', types: CLIMATE, default: 0.5,
+      help: 'How much the temperature moves each time it is adjusted.' },
+    { key: 'temperatureDisplayUnits', label: 'Display units', type: 'select', group: 'temperature', types: ['air-conditioner'], default: 'C',
+      options: [{ value: 'C', label: 'Celsius' }, { value: 'F', label: 'Fahrenheit' }],
+      help: 'Units shown in the Home app.' },
+    { key: 'temperatureUnits', label: 'Config units', type: 'select', group: 'temperature', types: ['heater-cooler'], default: 'C',
+      options: [{ value: 'C', label: 'Celsius' }, { value: 'F', label: 'Fahrenheit' }],
+      help: 'The units the temperatures in this accessory are written in.' },
+    { key: 'defaultCoolTemperature', label: 'Default cool temperature', type: 'number', group: 'temperature', types: ['air-conditioner'], default: 16,
+      help: 'Used when no code exists for the requested temperature.' },
+    { key: 'defaultHeatTemperature', label: 'Default heat temperature', type: 'number', group: 'temperature', types: ['air-conditioner'], default: 30,
+      help: 'Used when no code exists for the requested temperature.' },
+    { key: 'heatTemperature', label: 'Heating threshold', type: 'number', group: 'temperature', types: ['air-conditioner'],
+      help: 'Above this the accessory shows as heating, and the heat default is used for missing codes.' },
+    { key: 'replaceAutoMode', label: 'Replace auto mode with', type: 'select', group: 'temperature', types: ['air-conditioner'], default: 'cool',
+      options: [{ value: 'cool', label: 'Cool' }, { value: 'heat', label: 'Heat' }],
+      help: 'Siri sets auto mode; this is the mode used instead.' },
+    { key: 'autoHeatTemperature', label: 'Auto heat below', type: 'number', group: 'temperature', types: ['air-conditioner'],
+      help: 'Switches to heat mode when the measured temperature falls below this.' },
+    { key: 'autoCoolTemperature', label: 'Auto cool above', type: 'number', group: 'temperature', types: ['air-conditioner'],
+      help: 'Switches to cool mode when the measured temperature rises above this.' },
+    { key: 'autoSwitchName', label: 'Auto switch accessory', type: 'text', group: 'temperature', types: ['air-conditioner'],
+      help: 'Name of a switch accessory that turns the automatic heating and cooling on and off.' },
+    { key: 'minimumAutoOnOffDuration', label: 'Minimum auto on/off time', type: 'number', unit: 'seconds', group: 'temperature', types: ['air-conditioner'], default: 120,
+      help: 'How long the unit must stay on or off after being switched automatically.' },
+    { key: 'coolingThresholdTemperature', label: 'Cooling target', type: 'number', group: 'temperature', types: ['heater-cooler'], default: 35,
+      help: 'Temperature the cooler is set to.' },
+    { key: 'heatingThresholdTemperature', label: 'Heating target', type: 'number', group: 'temperature', types: ['heater-cooler'], default: 10,
+      help: 'Temperature the heater is set to.' },
+    { key: 'defaultRotationSpeed', label: 'Default fan speed', type: 'number', unit: '%', group: 'temperature', types: ['heater-cooler'], default: 100,
+      help: 'Fan speed used when the unit is turned on.' },
+    { key: 'fanStepSize', label: 'Fan step size', type: 'number', unit: '%', group: 'temperature', types: ['heater-cooler'], default: 1,
+      help: 'How much the fan speed moves each time it is adjusted.' },
+    { key: 'heatOnly', label: 'Heat only', type: 'boolean', group: 'temperature', types: ['air-conditioner'], default: false,
+      help: 'Restricts the accessory to heating.' },
+    { key: 'coolOnly', label: 'Cool only', type: 'boolean', group: 'temperature', types: ['air-conditioner'], default: false,
+      help: 'Restricts the accessory to cooling.' },
+    { key: 'turnOnWhenOff', label: 'Send on code first', type: 'boolean', group: 'temperature', types: CLIMATE, default: false,
+      help: 'Sends the on code before the temperature code when the unit is off.' },
+    { key: 'sendTemperatureOnlyWhenOff', label: 'Do not turn on for a temperature change', type: 'boolean', group: 'temperature', types: ['air-conditioner'], default: false,
+      help: 'Stops the unit being turned on when a temperature is set while it is off.' },
+    { key: 'ignoreTemperatureWhenOff', label: 'Ignore temperature while off', type: 'boolean', group: 'temperature', types: ['air-conditioner'], default: false,
+      help: 'Stops temperature codes being sent at all while the unit is off.' },
+    { key: 'temperatureAdjustment', label: 'Temperature offset', type: 'number', group: 'temperature', types: ['air-conditioner', 'heater-cooler', 'temperatureSensor'], default: 0,
+      help: 'Degrees added to the reading before it is reported.' },
+    { key: 'temperatureUpdateFrequency', label: 'Read temperature every', type: 'number', unit: 'seconds', group: 'temperature', types: ['air-conditioner', 'heater-cooler', 'temperatureSensor'], default: 10,
+      help: 'How often the temperature is requested.' },
+    { key: 'pseudoDeviceTemperature', label: 'Fixed temperature', type: 'number', group: 'temperature', types: ['air-conditioner', 'temperatureSensor'],
+      help: 'Reports this value instead of reading the device, for RM units without a thermometer.' },
+    { key: 'defaultNowTemperature', label: 'Fixed temperature', type: 'number', group: 'temperature', types: ['heater-cooler'],
+      help: 'Reports this value instead of reading the device, for RM units without a thermometer.' },
+    { key: 'temperatureFilePath', label: 'Temperature from file', type: 'text', group: 'mqtt', types: ['air-conditioner', 'heater-cooler', 'temperatureSensor'],
+      help: 'Path to a file holding the current temperature.' },
+    { key: 'w1DeviceID', label: '1-Wire sensor ID', type: 'text', group: 'mqtt', types: ['air-conditioner', 'heater-cooler', 'temperatureSensor'],
+      help: 'Reads the temperature from a Raspberry Pi 1-Wire sensor, for example 28-0321544e531ff.' },
+    { key: 'tempSourceUnits', label: 'Source units', type: 'select', group: 'mqtt', types: HISTORY_TYPES, default: 'C',
+      options: [{ value: 'C', label: 'Celsius' }, { value: 'F', label: 'Fahrenheit' }],
+      help: 'The units used by the file, MQTT or 1-Wire source. Not the RM device.' },
+
+    // --------------------------------------------------------------- humidity
+    { key: 'noHumidity', label: 'Hide humidity', type: 'boolean', group: 'humidity', types: HUMIDITY_TYPES, default: false,
+      help: 'Removes humidity reporting from the accessory.' },
+    { key: 'humidityAdjustment', label: 'Humidity offset', type: 'number', unit: '%', group: 'humidity', types: HUMIDITY_TYPES, default: 0,
+      help: 'Percentage added to the reading before it is reported.' },
+    { key: 'humidityUpdateFrequency', label: 'Read humidity every', type: 'number', unit: 'seconds', group: 'humidity', types: ['humidifier-dehumidifier', 'humiditySensor'], default: 10,
+      help: 'How often the humidity is requested.' },
+    { key: 'humidityFilePath', label: 'Humidity from file', type: 'text', group: 'mqtt', types: ['humidifier-dehumidifier', 'humiditySensor'],
+      help: 'Path to a file holding the current humidity.' },
+    { key: 'threshold', label: 'Humidity threshold', type: 'number', unit: '%', group: 'humidity', types: ['humidifier-dehumidifier'], default: 5,
+      help: 'How close to the target humidity the unit tries to get.' },
+    { key: 'humidifierOnly', label: 'Humidifier only', type: 'boolean', group: 'humidity', types: ['humidifier-dehumidifier'], default: false,
+      help: 'Restricts the accessory to humidifying.' },
+    { key: 'deHumidifierOnly', label: 'Dehumidifier only', type: 'boolean', group: 'humidity', types: ['humidifier-dehumidifier'], default: false,
+      help: 'Restricts the accessory to dehumidifying.' },
+
+    // ------------------------------------------------------------------- mqtt
+    { key: 'mqttURL', label: 'MQTT broker URL', type: 'text', group: 'mqtt', types: HISTORY_TYPES,
+      help: 'Must start with mqtt://, for example mqtt://192.168.1.77.' },
+    { key: 'mqttUsername', label: 'MQTT username', type: 'text', group: 'mqtt', types: HISTORY_TYPES,
+      help: 'Username for the broker, if it needs one.' },
+    { key: 'mqttPassword', label: 'MQTT password', type: 'password', group: 'mqtt', types: HISTORY_TYPES,
+      help: 'Password for the broker, if it needs one.' },
+    { key: 'batteryAlerts', label: 'Monitor battery level', type: 'boolean', group: 'mqtt', types: ['temperatureSensor', 'humiditySensor'], default: false,
+      help: 'Reads battery: values from the file or MQTT source and reports them to the Eve app.' },
+
+    // --------------------------------------------------------------- advanced
+    { key: 'persistState', label: 'Remember state across restarts', type: 'boolean', group: 'advanced', types: ALL, default: true,
+      help: 'Restores the last known state when Homebridge restarts.' },
+    { key: 'resendHexAfterReload', label: 'Resend code after restart', type: 'boolean', group: 'advanced', types: ALL, default: false,
+      help: 'Sends the code for the restored state when Homebridge restarts.' },
+    { key: 'allowResend', label: 'Allow resending the same code', type: 'boolean', group: 'advanced', types: ALL, default: true,
+      help: 'Sends the code even when the accessory is already in the requested state.' },
+    { key: 'noHistory', label: 'Disable Eve history', type: 'boolean', group: 'advanced', types: HISTORY_TYPES, default: false,
+      help: 'Removes the temperature and humidity history service used by the Eve app.' },
+    { key: 'disableLogs', label: 'Disable logging', type: 'boolean', group: 'advanced', types: ALL, default: false,
+      help: 'Silences this accessory in the Homebridge log.' },
+    { key: 'logLevel', label: 'Log level', type: 'select', group: 'advanced', types: ALL, default: 'info',
+      options: LOG_LEVELS, help: 'How much detail this accessory writes to the log.' }
+  ];
+
+  // Accessory types that carry a "data" object of hex codes.
+  var DATA_TYPES = ALL.filter(function (t) {
+    return ['temperatureSensor', 'humiditySensor', 'learn-code', 'learn-ir'].indexOf(t) === -1;
+  });
+
+  function optionsFor(type) {
+    return OPTIONS.filter(function (option) {
+      return option.types.indexOf(type) !== -1;
+    });
+  }
+
+  function typeLabel(type) {
+    for (var i = 0; i < ACCESSORY_TYPES.length; i += 1) {
+      if (ACCESSORY_TYPES[i].value === type) {return ACCESSORY_TYPES[i].label;}
+    }
+    return type;
+  }
+
+  // Starting points for the "data" object of each accessory type. They are only
+  // offered when an accessory has no codes yet, so an existing configuration is
+  // never overwritten.
+  var DATA_TEMPLATES = {
+    'switch': { on: '', off: '' },
+    'outlet': { on: '', off: '' },
+    'light': { on: '', off: '', brightness100: '' },
+    'fan': { on: '', off: '', swingToggle: '', fanSpeed100: '' },
+    'fanv1': { on: '', off: '', fanSpeed100: '' },
+    'air-purifier': { on: '', off: '' },
+    'air-conditioner': { off: '', temperature16: { 'pseudo-mode': 'cool', data: '' } },
+    'heater-cooler': { cool: { on: '', off: '', temperatureCodes: {} } },
+    'humidifier-dehumidifier': { on: '', off: '', targetStateHumidifier: '', targetStateDehumidifier: '' },
+    'garage-door-opener': { open: '', close: '' },
+    'lock': { lock: '', unlock: '' },
+    'window-covering': { open: '', close: '', stop: '' },
+    'window': { open: '', close: '', stop: '' },
+    'tv': { on: '', off: '', volume: { up: '', down: '' }, remote: {}, inputs: [] },
+    'switch-multi': { on: [''], off: [''] },
+    'switch-multi-repeat': { on: [''], off: [''] },
+    'switch-repeat': { on: '', off: '' }
+  };
+
+  // ------------------------------------------------------------------ codes
+  //
+  // Every hex code an accessory can hold, so the editor can offer a labelled
+  // slot to learn into instead of asking for hand-written JSON.
+  //
+  //   path   - dotted path inside the accessory's "data" object
+  //   label  - what the button on the remote does
+  //   group  - heading it appears under
+
+  var TV_REMOTE = [
+    ['select', 'OK / Select'], ['back', 'Back'], ['exit', 'Exit'], ['info', 'Info'],
+    ['arrowUp', 'Up'], ['arrowDown', 'Down'], ['arrowLeft', 'Left'], ['arrowRight', 'Right'],
+    ['playPause', 'Play / Pause'], ['rewind', 'Rewind'], ['fastForward', 'Fast forward'],
+    ['previousTrack', 'Previous track'], ['nextTrack', 'Next track']
+  ].map(function (pair) {
+    return { path: 'remote.' + pair[0], label: pair[1], group: 'Remote buttons' };
+  });
+
+  var POWER = [
+    { path: 'on', label: 'Turn on', group: 'Power' },
+    { path: 'off', label: 'Turn off', group: 'Power' }
+  ];
+
+  var CODE_SLOTS = {
+    'switch': POWER,
+    'outlet': POWER,
+    'switch-repeat': POWER,
+    'switch-multi': [
+      { path: 'on', label: 'Turn on', group: 'Power', list: true },
+      { path: 'off', label: 'Turn off', group: 'Power', list: true }
+    ],
+    'switch-multi-repeat': [
+      { path: 'on', label: 'Turn on', group: 'Power', list: true },
+      { path: 'off', label: 'Turn off', group: 'Power', list: true }
+    ],
+    'light': [
+      { path: 'on', label: 'Turn on', group: 'Power', optional: true },
+      { path: 'off', label: 'Turn off', group: 'Power' },
+      { path: 'white', label: 'Set to white', group: 'Colour', optional: true }
+    ],
+    'fan': POWER.concat([
+      { path: 'swingToggle', label: 'Toggle swing', group: 'Movement', optional: true },
+      { path: 'clockwise', label: 'Rotate clockwise', group: 'Movement', optional: true },
+      { path: 'counterClockwise', label: 'Rotate counter-clockwise', group: 'Movement', optional: true }
+    ]),
+    'fanv1': POWER,
+    'air-purifier': POWER.concat([
+      { path: 'swingToggle', label: 'Toggle swing', group: 'Movement', optional: true },
+      { path: 'lockControls', label: 'Lock the controls', group: 'Child lock', optional: true },
+      { path: 'unlockControls', label: 'Unlock the controls', group: 'Child lock', optional: true }
+    ]),
+    'humidifier-dehumidifier': POWER.concat([
+      { path: 'targetStateHumidifier', label: 'Humidifier mode', group: 'Mode' },
+      { path: 'targetStateDehumidifier', label: 'Dehumidifier mode', group: 'Mode' },
+      { path: 'fanOnly', label: 'Fan only', group: 'Mode', optional: true },
+      { path: 'swingToggle', label: 'Toggle swing', group: 'Movement', optional: true },
+      { path: 'lockControls', label: 'Lock the controls', group: 'Child lock', optional: true },
+      { path: 'unlockControls', label: 'Unlock the controls', group: 'Child lock', optional: true }
+    ]),
+    'air-conditioner': [
+      { path: 'off', label: 'Turn off', group: 'Power' },
+      { path: 'on', label: 'Turn on', group: 'Power', optional: true },
+      { path: 'offDryMode', label: 'Turn off with coil dry', group: 'Power', optional: true }
+    ],
+    'heater-cooler': [
+      { path: 'cool.on', label: 'Cool mode on', group: 'Cooling' },
+      { path: 'cool.off', label: 'Cool mode off', group: 'Cooling' },
+      { path: 'heat.on', label: 'Heat mode on', group: 'Heating' },
+      { path: 'heat.off', label: 'Heat mode off', group: 'Heating' }
+    ],
+    'garage-door-opener': [
+      { path: 'open', label: 'Open', group: 'Door' },
+      { path: 'close', label: 'Close', group: 'Door' },
+      { path: 'lock', label: 'Lock', group: 'Lock', optional: true },
+      { path: 'unlock', label: 'Unlock', group: 'Lock', optional: true }
+    ],
+    'lock': [
+      { path: 'lock', label: 'Lock', group: 'Lock' },
+      { path: 'unlock', label: 'Unlock', group: 'Lock' }
+    ],
+    'window-covering': [
+      { path: 'open', label: 'Open', group: 'Movement' },
+      { path: 'close', label: 'Close', group: 'Movement' },
+      { path: 'stop', label: 'Stop', group: 'Movement' },
+      { path: 'openCompletely', label: 'Open completely', group: 'Movement', optional: true },
+      { path: 'closeCompletely', label: 'Close completely', group: 'Movement', optional: true }
+    ],
+    'tv': [
+      { path: 'on', label: 'Turn on', group: 'Power' },
+      { path: 'off', label: 'Turn off', group: 'Power' },
+      { path: 'volume.up', label: 'Volume up', group: 'Volume' },
+      { path: 'volume.down', label: 'Volume down', group: 'Volume' },
+      { path: 'powerMode.show', label: 'Open the settings menu', group: 'Power', optional: true }
+    ].concat(TV_REMOTE)
+  };
+
+  CODE_SLOTS.window = CODE_SLOTS['window-covering'];
+
+  // Codes that come in numbered sets. The editor asks for the number and builds
+  // the key, rather than listing every possible one up front.
+  var CODE_FAMILIES = {
+    'light': [
+      { id: 'brightness', label: 'Brightness level', group: 'Brightness', unit: '%',
+        key: function (n) { return 'brightness' + n; }, min: 1, max: 100, step: 10 },
+      { id: 'hue', label: 'Colour (hue)', group: 'Colour', unit: 'degrees',
+        key: function (n) { return 'hue' + n; }, min: 0, max: 359, step: 1 }
+    ],
+    'fan': [
+      { id: 'fanSpeed', label: 'Fan speed', group: 'Speed', unit: '%',
+        key: function (n) { return 'fanSpeed' + n; }, min: 1, max: 100, step: 10 }
+    ],
+    'air-conditioner': [
+      { id: 'temperature', label: 'Temperature', group: 'Temperatures', unit: 'degrees',
+        key: function (n) { return 'temperature' + n; }, min: 10, max: 40, step: 1, mode: true }
+    ]
+  };
+
+  CODE_FAMILIES.fanv1 = CODE_FAMILIES.fan;
+  CODE_FAMILIES['air-purifier'] = CODE_FAMILIES.fan;
+  CODE_FAMILIES['humidifier-dehumidifier'] = CODE_FAMILIES.fan;
+
+  // Read a dotted path out of an accessory's data object. A slot's value is
+  // either a hex string or an object carrying the hex under "data", so both
+  // shapes are unwrapped to the string the editor shows.
+  function readCode(data, path) {
+    var node = data;
+    var parts = path.split('.');
+
+    for (var i = 0; i < parts.length; i += 1) {
+      if (node === null || typeof node !== 'object') { return undefined; }
+      node = node[parts[i]];
+    }
+
+    if (node === undefined || node === null) { return undefined; }
+    if (typeof node === 'string') { return node; }
+    if (Array.isArray(node)) { return node.length ? '[' + node.length + ' codes]' : undefined; }
+    if (typeof node === 'object' && typeof node.data === 'string') { return node.data; }
+    return undefined;
+  }
+
+  // Write a hex string into a dotted path, keeping whatever shape is already
+  // there: an object slot keeps its siblings (pseudo-mode, sendCount, ...) and
+  // only its "data" is replaced. Passing null removes the slot.
+  function writeCode(data, path, hex) {
+    var parts = path.split('.');
+    var node = data;
+
+    for (var i = 0; i < parts.length - 1; i += 1) {
+      if (node[parts[i]] === null || typeof node[parts[i]] !== 'object') { node[parts[i]] = {}; }
+      node = node[parts[i]];
+    }
+
+    var last = parts[parts.length - 1];
+
+    if (hex === null) {
+      delete node[last];
+      return;
+    }
+
+    var existing = node[last];
+
+    if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+      existing.data = hex;
+    } else {
+      node[last] = hex;
+    }
+  }
+
+  function slotsFor(accessory) {
+    var fixed = (CODE_SLOTS[accessory.type] || []).slice();
+    var data = accessory.data;
+
+    if (!data || typeof data !== 'object') { return fixed; }
+
+    var known = {};
+    fixed.forEach(function (slot) { known[slot.path] = true; });
+
+    // Anything already in the configuration that is not a fixed slot - a
+    // learned temperature, a fan speed, a code added by hand - is listed too,
+    // so nothing in the file is invisible in the editor.
+    Object.keys(data).forEach(function (key) {
+      if (known[key]) { return; }
+      if (key === 'remote' || key === 'volume' || key === 'inputs' || key === 'powerMode') { return; }
+      if (data[key] === null || typeof data[key] === 'object') {
+        if (Array.isArray(data[key]) || typeof data[key].data === 'string') {
+          fixed.push({ path: key, label: key, group: 'From your configuration', extra: true });
+        }
+        return;
+      }
+      fixed.push({ path: key, label: key, group: 'From your configuration', extra: true });
+    });
+
+    return fixed;
+  }
+
+  global.BroadlinkOptions = {
+    ACCESSORY_TYPES: ACCESSORY_TYPES,
+    LOG_LEVELS: LOG_LEVELS,
+    GROUPS: GROUPS,
+    OPTIONS: OPTIONS,
+    DATA_TYPES: DATA_TYPES,
+    DATA_TEMPLATES: DATA_TEMPLATES,
+    CODE_SLOTS: CODE_SLOTS,
+    CODE_FAMILIES: CODE_FAMILIES,
+    readCode: readCode,
+    writeCode: writeCode,
+    slotsFor: slotsFor,
+    SWITCH_LIKE: SWITCH_LIKE,
+    optionsFor: optionsFor,
+    typeLabel: typeLabel
+  };
+}(window));

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -1,0 +1,436 @@
+const { HomebridgePluginUiServer, RequestError } = require('@homebridge/plugin-ui-utils');
+const BroadlinkJS = require('kiwicam-broadlinkjs-rm');
+
+const DEFAULT_SCAN_SECONDS = 12;
+const MAX_SCAN_SECONDS = 60;
+
+// A session holds authenticated devices open between requests so that learning
+// does not have to re-discover. It is torn down once nothing has used it for a
+// while, and again when the UI process exits.
+const SESSION_IDLE_MS = 10 * 60 * 1000;
+
+const IR_TIMEOUT_MS = 30 * 1000;
+const RF_TIMEOUT_MS = 60 * 1000;
+const CONTINUOUS_IDLE_MS = 180 * 1000;
+const POLL_MS = 1000;
+
+// RM Pro and RM3 Pro Plus finish the RF sweep by entering ordinary learning
+// mode; every other model has a second frequency step first.
+const RF_SINGLE_STEP_TYPES = [0x279d, 0x27a9];
+
+const macToString = (mac) => {
+  const hex = Buffer.isBuffer(mac) ? mac.toString('hex') : String(mac);
+  return (hex.match(/[\s\S]{1,2}/g) || []).join(':').toLowerCase();
+};
+
+const macToKey = (mac) => String(mac || '').toLowerCase().replace(/[^0-9a-f]/g, '');
+
+class UiServer extends HomebridgePluginUiServer {
+  constructor() {
+    super();
+
+    this.session = null;
+    this.sessionTimer = null;
+    this.learning = null;
+
+    this.onRequest('/discover', this.discover.bind(this));
+    this.onRequest('/learn/start', this.learnStart.bind(this));
+    this.onRequest('/learn/stop', this.learnStopRequest.bind(this));
+    this.onRequest('/send', this.send.bind(this));
+
+    this.ready();
+  }
+
+  // ---------------------------------------------------------------- session
+
+  touchSession() {
+    if (this.sessionTimer) { clearTimeout(this.sessionTimer); }
+
+    this.sessionTimer = setTimeout(() => {
+      this.learnStop('stopped');
+      this.closeSession();
+    }, SESSION_IDLE_MS);
+  }
+
+  closeSession() {
+    if (!this.session) { return; }
+
+    const broadlink = this.session.broadlink;
+    this.session = null;
+
+    (broadlink.sockets || []).forEach((socket) => {
+      try {
+        socket.close();
+      } catch (err) {
+        // Already closed.
+      }
+    });
+
+    Object.keys(broadlink.devices || {}).forEach((key) => {
+      const device = broadlink.devices[key];
+      if (device && typeof device === 'object' && device.socket) {
+        try {
+          device.socket.close();
+        } catch (err) {
+          // Already closed.
+        }
+      }
+    });
+  }
+
+  /**
+   * Broadcast a Broadlink discovery packet and report everything that answers.
+   *
+   * The reply carries the device's MAC, its current address, its type and
+   * whether it has been locked to the Broadlink cloud, so a device that is
+   * present but unusable can be told apart from one that is simply missing.
+   */
+  discover(payload) {
+    const requested = payload && payload.seconds ? Number(payload.seconds) : DEFAULT_SCAN_SECONDS;
+    const seconds = Math.min(Math.max(requested || DEFAULT_SCAN_SECONDS, 3), MAX_SCAN_SECONDS);
+
+    this.learnStop('stopped');
+    this.closeSession();
+
+    return new Promise((resolve, reject) => {
+      let broadlink;
+
+      try {
+        broadlink = new BroadlinkJS();
+      } catch (err) {
+        reject(new RequestError('Could not start the Broadlink discovery service.', { message: err.message }));
+        return;
+      }
+
+      // The library logs directly; keep the UI server quiet.
+      broadlink.log = () => {};
+      broadlink.debug = false;
+
+      const found = new Map();
+      const session = { broadlink, found };
+      this.session = session;
+
+      const originalOnMessage = broadlink.onMessage.bind(broadlink);
+
+      const macOf = (message) => {
+        const mac = Buffer.alloc(6, 0);
+        for (let i = 0; i < 6; i += 1) {
+          message.copy(mac, i, 0x3f - i);
+        }
+        return mac;
+      };
+
+      // discover() binds this.onMessage when it opens its sockets, so replacing
+      // it here means every reply is seen before the library decides whether to
+      // create a device for it.
+      broadlink.onMessage = (message, host) => {
+        let key = null;
+
+        try {
+          const mac = macOf(message);
+          key = mac.toString('hex');
+
+          const deviceType = message[0x34] | (message[0x35] << 8);
+          const existing = found.get(key) || {};
+
+          found.set(key, Object.assign(existing, {
+            mac: macToString(mac),
+            address: host.address,
+            port: host.port,
+            deviceType: '0x' + deviceType.toString(16),
+            locked: Boolean(message[0x7f]),
+            linkLocal: typeof host.address === 'string' && host.address.indexOf('169.254.') === 0,
+            authenticated: existing.authenticated === true
+          }));
+        } catch (err) {
+          // A malformed reply should not stop the scan.
+        }
+
+        originalOnMessage(message, host);
+
+        // The library has now had a chance to build a device for this reply, so
+        // the model name and RF capability can be read back off it.
+        try {
+          const device = key ? broadlink.devices[key] : null;
+          const record = key ? found.get(key) : null;
+
+          if (record && device && typeof device === 'object') {
+            record.model = device.model;
+            record.supportsRF = typeof device.enterRFSweep === 'function';
+            record.supportsLearning = typeof device.enterLearning === 'function';
+          } else if (record && !record.model) {
+            record.model = null;
+            record.supportsRF = false;
+            record.supportsLearning = false;
+          }
+        } catch (err) {
+          // Ignore - the scan result is still useful without the model name.
+        }
+      };
+
+      broadlink.on('deviceReady', (device) => {
+        const record = found.get(Buffer.isBuffer(device.mac) ? device.mac.toString('hex') : String(device.mac));
+        if (record) {
+          record.authenticated = true;
+          record.address = device.host.address;
+        }
+      });
+
+      const interval = setInterval(() => {
+        try {
+          broadlink.discover();
+        } catch (err) {
+          // Interface came and went mid-scan; the next tick will retry.
+        }
+      }, 2000);
+
+      try {
+        broadlink.discover();
+      } catch (err) {
+        clearInterval(interval);
+        reject(new RequestError('Could not send the discovery broadcast.', { message: err.message }));
+        return;
+      }
+
+      setTimeout(() => {
+        clearInterval(interval);
+
+        // The discovery sockets have done their job; the per-device sockets
+        // stay open so a learn request does not have to scan again.
+        (broadlink.sockets || []).forEach((socket) => {
+          try {
+            socket.close();
+          } catch (err) {
+            // Already closed.
+          }
+        });
+        broadlink.sockets = [];
+
+        this.touchSession();
+
+        const devices = Array.from(found.values()).sort((a, b) => a.mac.localeCompare(b.mac));
+
+        resolve({ devices, scannedFor: seconds });
+      }, seconds * 1000);
+    });
+  }
+
+  // Find an authenticated device, scanning once if this is the first request.
+  deviceFor(mac) {
+    const key = macToKey(mac);
+
+    if (!key) {
+      return Promise.reject(new RequestError('No Broadlink device was chosen for this accessory.', { status: 400 }));
+    }
+
+    const fromSession = () => {
+      const device = this.session ? this.session.broadlink.devices[key] : null;
+      return device && typeof device === 'object' ? device : null;
+    };
+
+    const existing = fromSession();
+    if (existing) {
+      this.touchSession();
+      return Promise.resolve(existing);
+    }
+
+    return this.discover({ seconds: 8 }).then(() => {
+      const device = fromSession();
+
+      if (!device) {
+        throw new RequestError('That Broadlink device did not answer. Check that it is powered on and on the same network.', { status: 404 });
+      }
+
+      return device;
+    });
+  }
+
+  // ----------------------------------------------------------------- learn
+
+  status(state, message) {
+    this.pushEvent('learn-status', { state, message });
+  }
+
+  learnStop(state, message) {
+    const learning = this.learning;
+    if (!learning) { return; }
+
+    this.learning = null;
+    learning.stopped = true;
+
+    learning.timers.forEach((timer) => clearTimeout(timer));
+    learning.intervals.forEach((interval) => clearInterval(interval));
+
+    Object.keys(learning.listeners).forEach((event) => {
+      try {
+        learning.device.removeListener(event, learning.listeners[event]);
+      } catch (err) {
+        // The device may already be gone.
+      }
+    });
+
+    try {
+      learning.device.cancelLearn();
+    } catch (err) {
+      // Nothing to cancel.
+    }
+
+    if (state) { this.status(state, message); }
+  }
+
+  learnStopRequest() {
+    this.learnStop('stopped', 'Learning stopped.');
+    return { state: 'stopped' };
+  }
+
+  learnStart(payload) {
+    const mode = payload && payload.mode === 'rf' ? 'rf' : 'ir';
+    const continuous = Boolean(payload && payload.continuous);
+
+    return this.deviceFor(payload && payload.mac).then((device) => {
+      this.learnStop();
+
+      if (typeof device.enterLearning !== 'function') {
+        throw new RequestError('This Broadlink model cannot learn codes.', { status: 400 });
+      }
+
+      if (mode === 'rf' && typeof device.enterRFSweep !== 'function') {
+        throw new RequestError('This Broadlink model cannot learn RF codes. An RM Pro or RM4 Pro is needed.', { status: 400 });
+      }
+
+      const learning = {
+        device,
+        mode,
+        continuous,
+        stopped: false,
+        timers: [],
+        intervals: [],
+        listeners: {}
+      };
+
+      this.learning = learning;
+
+      const listen = (event, handler) => {
+        learning.listeners[event] = handler;
+        device.on(event, handler);
+      };
+
+      const poll = (fn) => {
+        const interval = setInterval(() => {
+          if (learning.stopped) { return; }
+          try {
+            fn();
+          } catch (err) {
+            // A dropped packet is retried on the next tick.
+          }
+        }, POLL_MS);
+        learning.intervals.push(interval);
+        return interval;
+      };
+
+      const expire = (ms, state, message) => {
+        const timer = setTimeout(() => this.learnStop(state, message), ms);
+        learning.timers.push(timer);
+        return timer;
+      };
+
+      const captured = (message) => {
+        if (learning.stopped) { return; }
+
+        this.pushEvent('learn-code', { hex: message.toString('hex'), mode });
+
+        if (!continuous) {
+          this.learnStop();
+          this.status('captured', 'Code received.');
+          return;
+        }
+
+        // Keep the session open for the next button. The device has to be put
+        // back into learning mode after every capture.
+        learning.timers.forEach((timer) => clearTimeout(timer));
+        learning.timers = [];
+
+        try {
+          device.cancelLearn();
+        } catch (err) {
+          // Nothing to cancel.
+        }
+
+        const resume = setTimeout(() => {
+          if (learning.stopped) { return; }
+          try {
+            device.enterLearning();
+          } catch (err) {
+            // The next poll will surface the failure as a timeout.
+          }
+          this.status('waiting', 'Ready for the next button.');
+        }, 500);
+
+        learning.timers.push(resume);
+        expire(CONTINUOUS_IDLE_MS, 'timeout', 'Stopped after three minutes without a button press.');
+      };
+
+      if (mode === 'ir') {
+        listen('rawData', captured);
+        device.enterLearning();
+        poll(() => device.checkData());
+        expire(continuous ? CONTINUOUS_IDLE_MS : IR_TIMEOUT_MS, 'timeout', 'No code was received.');
+
+        this.status('waiting', 'Point the remote at the Broadlink device and press the button.');
+
+        return { state: 'waiting', mode, continuous };
+      }
+
+      // RF is a sweep: find the frequency, confirm it, then read the code.
+      let frequencyPoll = null;
+
+      listen('rawRFData', () => {
+        if (learning.stopped) { return; }
+
+        if (frequencyPoll) { clearInterval(frequencyPoll); }
+
+        if (RF_SINGLE_STEP_TYPES.indexOf(device.type) !== -1) {
+          device.enterLearning();
+          this.status('rf-press', 'Frequency found. Press the button again, in short bursts.');
+          poll(() => device.checkData());
+          return;
+        }
+
+        this.status('rf-holding', 'Frequency found. Keep holding the button.');
+        poll(() => device.checkRFData2());
+      });
+
+      listen('rawRFData2', () => {
+        if (learning.stopped) { return; }
+        this.status('rf-press', 'Now press the button several times, pausing between presses.');
+        poll(() => device.checkData());
+      });
+
+      listen('rawData', captured);
+
+      device.enterRFSweep();
+      frequencyPoll = poll(() => device.checkRFData());
+      expire(RF_TIMEOUT_MS, 'timeout', 'No RF code was received.');
+
+      this.status('rf-sweep', 'Hold down the button on the remote until the frequency is found.');
+
+      return { state: 'rf-sweep', mode, continuous };
+    });
+  }
+
+  // Send a code back out, so a mapped button can be checked without leaving
+  // the settings page.
+  send(payload) {
+    const hex = payload && payload.hex;
+
+    if (typeof hex !== 'string' || !/^[0-9a-fA-F]+$/.test(hex) || hex.length < 8) {
+      return Promise.reject(new RequestError('That does not look like a hex code.', { status: 400 }));
+    }
+
+    return this.deviceFor(payload && payload.mac).then((device) => {
+      return device.sendData(Buffer.from(hex, 'hex')).then(() => ({ sent: true }));
+    });
+  }
+}
+
+new UiServer();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.4.21",
       "license": "ISC",
       "dependencies": {
+        "@homebridge/plugin-ui-utils": "^1.0.3",
         "await-semaphore": "^0.1.3",
         "chai": "^4.3.7",
         "fakegato-history": "^0.6.5",
@@ -230,6 +231,12 @@
       "resolved": "https://registry.npmjs.org/@homebridge/long/-/long-5.2.1.tgz",
       "integrity": "sha512-i5Df8R63XNPCn+Nj1OgAoRdw9e+jHUQb3CNUbvJneI2iu3j4+OtzQj+5PA1Ce+747NR1SPqZSvyvD483dOT3AA==",
       "dev": true
+    },
+    "node_modules/@homebridge/plugin-ui-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@homebridge/plugin-ui-utils/-/plugin-ui-utils-1.0.3.tgz",
+      "integrity": "sha512-p2S/czGYNRnRtMICxBUk4Uar+KCezfyxjqfStfxKgykD2082SNayVDncYUK1xRai78EGHCbif9eoyrmDweh4tQ==",
+      "license": "MIT"
     },
     "node_modules/@homebridge/put": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "url": "git+ssh://git@github.com/kiwi-cam/homebridge-broadlink-rm.git"
   },
   "dependencies": {
+    "@homebridge/plugin-ui-utils": "^1.0.3",
     "await-semaphore": "^0.1.3",
     "chai": "^4.3.7",
     "fakegato-history": "^0.6.5",


### PR DESCRIPTION
### The problem

The plugin has no `config.schema.json`, so Homebridge UI can only offer the raw
JSON editor. Everything — the platform options, which options apply to which
accessory type, and the shape of the hex data — has to be looked up in the
documentation and typed by hand, and a misplaced comma is only discovered when
Homebridge fails to start.

### The change

Adds `config.schema.json` and a custom UI built on
`@homebridge/plugin-ui-utils`.

**Devices.** A scan broadcasts a discovery packet and lists everything that
answers, with its model, MAC and current address. Each device is reported as
ready, locked to the Broadlink cloud, or holding a link-local `169.254.x.x`
address, with an explanation of what to do about it. Those two failures look
identical from the log — the device is simply absent — so they are called out
explicitly. A device can be pinned into `hosts` with one click, which fills in
`address`, `mac`, `isRFSupported` and `isRM4`.

**Accessories.** A list with add, duplicate and delete, and an editor that shows
only the options that apply to the selected accessory type, each with a one-line
explanation taken from the documentation. Hex data is edited as JSON, with
validation and an optional starting template per type.

**Codes.** Each accessory type has a labelled slot for every hex code it can
hold — `on`, `off`, `volume.up`, the thirteen TV remote buttons, and so on — and
each slot has a **Learn** button. Pressing it puts the RM device into learning
mode and writes the captured code straight into the accessory: no reading it back
out of the log. RM Pro and RM4 Pro devices also get **Learn RF**, which runs the
frequency sweep with the same prompts the log gives today. A **Test** button
sends a learned code back out so the mapping can be checked on the spot, and
**Learn the N missing codes** walks a whole remote in one pass, keeping the
device in learning mode between button presses. Numbered code families —
temperatures, fan speeds, brightness levels, hues — are added from a picker
rather than typed as JSON keys.

**Settings.** The platform options, with the log levels as named choices.

### Notes on the implementation

- The custom UI edits the configuration object it was handed and writes it back
  through `updatePluginConfig()`, so anything it does not render — nested hex
  data, options added later — is round-tripped untouched.
- For the same reason `accessories` is deliberately **free-form** in
  `config.schema.json` rather than fully typed. A partial schema would let form
  validation reshape or drop hex data that took a long time to learn; that risk
  is not worth the validation.
- Only non-default values are written, so configurations stay readable and an
  option whose default changes later keeps following it.
- Learning writes through a path helper that keeps whatever shape a slot already
  has: a temperature slot keeps its `pseudo-mode`, a repeated code keeps its
  `sendCount`, and only `data` is replaced. Codes that are in the file but not in
  the slot catalogue are listed under "From your configuration", so nothing on
  disk is invisible in the editor.
- The learning flow is the same sequence `helpers/learnData.js` and
  `helpers/learnRFData.js` already use — `enterLearning()` / `enterRFSweep()`
  with a one-second poll — driven from the UI server's own session rather than
  from the Homebridge process, and reported to the page with `pushEvent`.
- The UI server keeps authenticated devices open between requests so learning
  does not have to re-scan, and tears the session down after ten minutes idle.
  Discovery sockets are closed as soon as a scan finishes.
- Every option in the accessory editor comes from a single catalogue in
  `homebridge-ui/public/js/options.js`, so adding an option to the UI is one
  entry in one file.
- `@homebridge/plugin-ui-utils` is pinned to `^1.0.3`, the last CommonJS release,
  to keep the package as it is. v2 is ESM only.

### Not covered

- **`rediscoveryInterval`** is not exposed here, so this PR stays independent of
  #786. One entry in `PLATFORM_FIELDS` adds it if both land.
- **TV inputs and code lists** (`switch-multi`, repeated codes) are still edited
  through the raw JSON block rather than having their own slot rows.
- **Continuous capture is IR only.** RF needs a fresh frequency sweep per code,
  so "learn the missing codes" in one pass does not apply to it.

### Testing

Against Homebridge UI 4.x with four RM4 Pro devices:

- the schema loads with `customUi` set and the expected properties;
- `GET /api/plugins/settings-ui/homebridge-broadlink-rm-pro/index.html` and its
  assets are served;
- a scan finds and correctly identifies all four devices;
- `/send` transmitted a real code from the running configuration without error;
- `npm ci` and `npm run lint` both clean; `npm pack --dry-run` confirms
  `config.schema.json` and `homebridge-ui/` ship in the tarball.

The learning state machine is covered by driving the device's own events in place
of a remote-control press: single capture, continuous capture re-arming between
presses, the three-stage RF sweep, listener removal after a capture, no capture
after stop, and rejection of a non-hex code or a missing device. The path helpers
are covered separately: nested paths, creating parents, preserving `pseudo-mode`
and other siblings on an object slot, deletion, arrays, and missing paths.

What I could not exercise is a physical remote-control press producing a real
code — my test devices are in different rooms, so one could not transmit into
another's receiver. The transport itself is unchanged from the flow the plugin
already uses today.