### PR TITLE
Fix Current Temperature read handler hanging when device poll response is lost

### DIFF
--- a/accessories/aircon.js
+++ b/accessories/aircon.js
@@ -524,6 +524,17 @@ class AirConAccessory extends BroadlinkRMAccessory {
 
     device.checkTemperature();
     if (logLevel <1) {log(`\x1b[34m[DEBUG]\x1b[0m ${name} addTemperatureCallbackToQueue (requested temperature from device, waiting)`);}
+
+    // The device may never respond (e.g. a dropped UDP packet). Without a timeout the HAP
+    // callback would be left pending indefinitely, causing Homebridge's "slow to respond" /
+    // "didn't respond at all" warnings for the Current Temperature characteristic.
+    setTimeout(() => {
+      if (this.temperatureCallbackQueue[callbackIdentifier]) {
+        if (logLevel <=3) {log(`${name} addTemperatureCallbackToQueue (device did not respond in time, using existing temperature)`);}
+        delete this.temperatureCallbackQueue[callbackIdentifier];
+        callback(null, state.currentTemperature || 0);
+      }
+    }, 3000);
   }
 
   updateTemperatureFromFile () {

--- a/test/airConditioner.test.js
+++ b/test/airConditioner.test.js
@@ -65,6 +65,26 @@ describe('airConAccessory', async () => {
     expect(airConAccessory.config.replaceAutoMode).to.equal('cool');
   });
 
+  it('getCurrentTemperature falls back when the device never responds', async () => {
+    const { device } = setup();
+    defaultConfig.host = device.host.address
+
+    const config = {
+      ...defaultConfig
+    };
+
+    const airConAccessory = new AirCon(null, config, 'FakeServiceManager');
+    airConAccessory.state.currentTemperature = 21;
+
+    // FakeDevice.checkTemperature() is a no-op and never emits a 'temperature'
+    // event, simulating a dropped UDP request/response with the real device.
+    const temperature = await new Promise((resolve) => {
+      airConAccessory.getCurrentTemperature((err, value) => resolve(value));
+    });
+
+    expect(temperature).to.equal(21);
+  }).timeout(5000);
+
   it('custom config', async () => {
     const { device } = setup();
     defaultConfig.host = device.host.address


### PR DESCRIPTION
## Summary

- `getCurrentTemperature()` queues the HAP read callback and waits for a `'temperature'` event produced by a UDP round-trip to the physical Broadlink RM device (`device.checkTemperature()`), with no timeout anywhere in that chain (verified: no `setTimeout`/`Promise.race` guarding it in `accessories/aircon.js` or `helpers/serviceManager.js`).
- If the request or response UDP packet is dropped — common on Wi-Fi, and this does **not** require the device to be considered fully `inactive` (that existing fallback only triggers when `device.state === 'inactive'`) — the queued callback is left pending indefinitely. Homebridge's own watchdog then logs the standard "slow to respond" (~3s) and "didn't respond at all" (~10s+) warnings for `Current Temperature`.
- This adds a 3s timeout in `addTemperatureCallbackToQueue` that resolves the pending callback with the last known temperature if the device hasn't responded in time, instead of leaving it hanging forever.

Fixes #788

## Test plan

- Added a regression test (`test/airConditioner.test.js`) using the existing `FakeDevice` test helper, whose `checkTemperature()` is a no-op that never emits a `'temperature'` event — simulating a dropped UDP request/response. It asserts `getCurrentTemperature`'s callback still resolves (with the last known temperature) instead of hanging.
- **Note:** I was unable to get the full existing mocha suite running in a clean checkout of this repo to confirm no regressions elsewhere — every test currently fails with `TypeError: Cannot read properties of undefined (reading 'user')` from `base/helpers/persistentState.js`, because `test/helpers/setup.js` never calls `BroadlinkRMPlatform.setHomebridge(...)` with a real `homebridge` object (that's only wired up from `index.js` when Homebridge itself loads the plugin). There's also a second, separate pre-existing issue where `test/helpers/fakeServiceManager.js`'s `FakeCharacteristic` is missing an `updateValue()` method that `helpers/serviceManager.js` now calls. `.github/workflows/pipeline.yml` only runs `npm run lint`, not the test suite, which is likely why this has gone unnoticed. Happy to open a separate PR for that if useful — didn't want to bundle an unrelated test-harness fix into this change.
- Manually verified the fix and the pre-fix hang with a standalone script exercising `getCurrentTemperature` against the `FakeDevice` helper directly (bypassing the broken harness plumbing above): before the fix the callback never fired; after the fix it resolved in ~3s with the fallback temperature.
- Deployed this change to my own Homebridge instance (real Broadlink RM4 Mini devices) and confirmed the plugin loads and runs cleanly with no regressions.
